### PR TITLE
Backend/253/erd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ tmp
 compliance/opencontrols/
 compliance/exports/
 
+# Graph Models ERD
+tdrs-backend/tdp-erd.png
+
 # coverage result
 .coverage
 /coverage/

--- a/tdrs-backend/Pipfile
+++ b/tdrs-backend/Pipfile
@@ -16,6 +16,7 @@ pytest-cov = "*"
 pytest-django = "*"
 pytest-mock = "*"
 pyparsing = "*"
+pygraphviz = "*"
 
 [packages]
 boto3 = "*"
@@ -40,7 +41,6 @@ ptpython = "*"
 pyjwt = "*"
 python-dotenv = "*"
 requests = "*"
-pygraphviz = "*"
 
 [requires]
 python_version = "3.8"

--- a/tdrs-backend/Pipfile
+++ b/tdrs-backend/Pipfile
@@ -15,6 +15,7 @@ pytest = "*"
 pytest-cov = "*"
 pytest-django = "*"
 pytest-mock = "*"
+pyparsing = "*"
 
 [packages]
 boto3 = "*"
@@ -39,6 +40,7 @@ ptpython = "*"
 pyjwt = "*"
 python-dotenv = "*"
 requests = "*"
+pygraphviz = "*"
 
 [requires]
 python_version = "3.8"

--- a/tdrs-backend/Pipfile.lock
+++ b/tdrs-backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8be8d03b6465633e72ad914162c415ac0d6adba4efded17093cad1048c027d30"
+            "sha256": "f37285af1a60f75ef46041162c3e5ca11db6ccdb4230e96a3019a32fa3c59357"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,18 +48,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:25c716b7c01d4664027afc6a6418a06459e311a610c7fd39a030a1ced1b72ce4",
-                "sha256:37158c37a151eab5b9080968305621a40168171fda9584d50a309ceb4e5e6964"
+                "sha256:28bf1bce2979d4d1674d63b1b4d6ac30b6844b5d3604e69d8847b18602588861",
+                "sha256:78f3ebcdff149d5327f27a5c461a9e394306b7db9a60e8bd65c9401cc41d99d3"
             ],
             "index": "pypi",
-            "version": "==1.14.63"
+            "version": "==1.15.0"
         },
         "botocore": {
             "hashes": [
-                "sha256:40f13f6c9c29c307a9dc5982739e537ddce55b29787b90c3447b507e3283bcd6",
-                "sha256:aa88eafc6295132f4bc606f1df32b3248e0fa611724c0a216aceda767948ac75"
+                "sha256:1dbd37af06432eda8a5736bd82f92ddd1ae8de74e4faa090bd728f8d58d24849",
+                "sha256:f3d509f06201582e60523263d52016b50415461bc6a03afb5434f477a1de3ba0"
             ],
-            "version": "==1.17.63"
+            "version": "==1.18.0"
         },
         "certifi": {
             "hashes": [
@@ -177,11 +177,11 @@
         },
         "django-extensions": {
             "hashes": [
-                "sha256:a67747508ec39583892fbddf57e0b66b3f332a885ef5520698bc2e1cb351955a",
-                "sha256:c7c2ca48ccc2ecc4427c908cd3a6dc114fc7534092de51209b02f84ccafe648b"
+                "sha256:6809c89ca952f0e08d4e0766bc0101dfaf508d7649aced1180c091d737046ea7",
+                "sha256:dc663652ac9460fd06580a973576820430c6d428720e874ae46b041fa63e0efa"
             ],
             "index": "pypi",
-            "version": "==3.0.8"
+            "version": "==3.0.9"
         },
         "django-filter": {
             "hashes": [
@@ -222,15 +222,6 @@
             ],
             "index": "pypi",
             "version": "==3.11.1"
-        },
-        "docutils": {
-            "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.15.2"
         },
         "gunicorn": {
             "hashes": [
@@ -402,13 +393,6 @@
             "markers": "python_version >= '3.5'",
             "version": "==2.7.1"
         },
-        "pygraphviz": {
-            "hashes": [
-                "sha256:411ae84a5bc313e3e1523a1cace59159f512336318a510573b47f824edef8860"
-            ],
-            "index": "pypi",
-            "version": "==1.6"
-        },
         "pyjwt": {
             "hashes": [
                 "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
@@ -484,7 +468,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "markers": "python_version != '3.4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         },
         "wcwidth": {
@@ -807,6 +791,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
+        },
+        "pygraphviz": {
+            "hashes": [
+                "sha256:411ae84a5bc313e3e1523a1cace59159f512336318a510573b47f824edef8860"
+            ],
+            "index": "pypi",
+            "version": "==1.6"
         },
         "pyparsing": {
             "hashes": [

--- a/tdrs-backend/Pipfile.lock
+++ b/tdrs-backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aa0786187e1bb1437174f3928ffe1c726d49018871f401940789abf11c00c95d"
+            "sha256": "8be8d03b6465633e72ad914162c415ac0d6adba4efded17093cad1048c027d30"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,18 +48,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:89939e68c6200154c326dfe791c6492ea8f78ba966de5e57308bc48847a16a91",
-                "sha256:cf186e0bcf3f0ecdc99cb4f4b579c39a30779ebaf050a3d74b2b4d2dd6b4abcf"
+                "sha256:25c716b7c01d4664027afc6a6418a06459e311a610c7fd39a030a1ced1b72ce4",
+                "sha256:37158c37a151eab5b9080968305621a40168171fda9584d50a309ceb4e5e6964"
             ],
             "index": "pypi",
-            "version": "==1.14.58"
+            "version": "==1.14.63"
         },
         "botocore": {
             "hashes": [
-                "sha256:37cc3f1013c00dc0f061582198d6b785dadf147bd99307d41c5c0e47debca65c",
-                "sha256:acd2df778a5e12b2a16ac040ce6e91a6c6f2d7ac67bd4f966472ce5c68b5b62d"
+                "sha256:40f13f6c9c29c307a9dc5982739e537ddce55b29787b90c3447b507e3283bcd6",
+                "sha256:aa88eafc6295132f4bc606f1df32b3248e0fa611724c0a216aceda767948ac75"
             ],
-            "version": "==1.17.58"
+            "version": "==1.17.63"
         },
         "certifi": {
             "hashes": [
@@ -201,11 +201,11 @@
         },
         "django-storages": {
             "hashes": [
-                "sha256:1e37da57678e6cf1e9914f84099a305323e4e1f261afe54fdb703cae7aa6fbc3",
-                "sha256:36ed8dab33d761954498189592ce005920095fcbc02dab4184eb51393c370991"
+                "sha256:12de8fb2605b9b57bfaf54b075280d7cbb3b3ee1ca4bc9b9add147af87fe3a2c",
+                "sha256:652275ab7844538c462b62810276c0244866f345878256a9e0e86f5b1283ae18"
             ],
             "index": "pypi",
-            "version": "==1.10"
+            "version": "==1.10.1"
         },
         "django-unique-upload": {
             "hashes": [
@@ -396,11 +396,18 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
-                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
+                "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998",
+                "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.6.1"
+            "version": "==2.7.1"
+        },
+        "pygraphviz": {
+            "hashes": [
+                "sha256:411ae84a5bc313e3e1523a1cace59159f512336318a510573b47f824edef8860"
+            ],
+            "index": "pypi",
+            "version": "==1.6"
         },
         "pyjwt": {
             "hashes": [
@@ -531,43 +538,43 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:098a703d913be6fbd146a8c50cc76513d726b022d170e5e98dc56d958fd592fb",
-                "sha256:16042dc7f8e632e0dcd5206a5095ebd18cb1d005f4c89694f7f8aafd96dd43a3",
-                "sha256:1adb6be0dcef0cf9434619d3b892772fdb48e793300f9d762e480e043bd8e716",
-                "sha256:27ca5a2bc04d68f0776f2cdcb8bbd508bbe430a7bf9c02315cd05fb1d86d0034",
-                "sha256:28f42dc5172ebdc32622a2c3f7ead1b836cdbf253569ae5673f499e35db0bac3",
-                "sha256:2fcc8b58953d74d199a1a4d633df8146f0ac36c4e720b4a1997e9b6327af43a8",
-                "sha256:304fbe451698373dc6653772c72c5d5e883a4aadaf20343592a7abb2e643dae0",
-                "sha256:30bc103587e0d3df9e52cd9da1dd915265a22fad0b72afe54daf840c984b564f",
-                "sha256:40f70f81be4d34f8d491e55936904db5c527b0711b2a46513641a5729783c2e4",
-                "sha256:4186fc95c9febeab5681bc3248553d5ec8c2999b8424d4fc3a39c9cba5796962",
-                "sha256:46794c815e56f1431c66d81943fa90721bb858375fb36e5903697d5eef88627d",
-                "sha256:4869ab1c1ed33953bb2433ce7b894a28d724b7aa76c19b11e2878034a4e4680b",
-                "sha256:4f6428b55d2916a69f8d6453e48a505c07b2245653b0aa9f0dee38785939f5e4",
-                "sha256:52f185ffd3291196dc1aae506b42e178a592b0b60a8610b108e6ad892cfc1bb3",
-                "sha256:538f2fd5eb64366f37c97fdb3077d665fa946d2b6d95447622292f38407f9258",
-                "sha256:64c4f340338c68c463f1b56e3f2f0423f7b17ba6c3febae80b81f0e093077f59",
-                "sha256:675192fca634f0df69af3493a48224f211f8db4e84452b08d5fcebb9167adb01",
-                "sha256:700997b77cfab016533b3e7dbc03b71d33ee4df1d79f2463a318ca0263fc29dd",
-                "sha256:8505e614c983834239f865da2dd336dcf9d72776b951d5dfa5ac36b987726e1b",
-                "sha256:962c44070c281d86398aeb8f64e1bf37816a4dfc6f4c0f114756b14fc575621d",
-                "sha256:9e536783a5acee79a9b308be97d3952b662748c4037b6a24cbb339dc7ed8eb89",
-                "sha256:9ea749fd447ce7fb1ac71f7616371f04054d969d412d37611716721931e36efd",
-                "sha256:a34cb28e0747ea15e82d13e14de606747e9e484fb28d63c999483f5d5188e89b",
-                "sha256:a3ee9c793ffefe2944d3a2bd928a0e436cd0ac2d9e3723152d6fd5398838ce7d",
-                "sha256:aab75d99f3f2874733946a7648ce87a50019eb90baef931698f96b76b6769a46",
-                "sha256:b1ed2bdb27b4c9fc87058a1cb751c4df8752002143ed393899edb82b131e0546",
-                "sha256:b360d8fd88d2bad01cb953d81fd2edd4be539df7bfec41e8753fe9f4456a5082",
-                "sha256:b8f58c7db64d8f27078cbf2a4391af6aa4e4767cc08b37555c4ae064b8558d9b",
-                "sha256:c1bbb628ed5192124889b51204de27c575b3ffc05a5a91307e7640eff1d48da4",
-                "sha256:c2ff24df02a125b7b346c4c9078c8936da06964cc2d276292c357d64378158f8",
-                "sha256:c890728a93fffd0407d7d37c1e6083ff3f9f211c83b4316fae3778417eab9811",
-                "sha256:c96472b8ca5dc135fb0aa62f79b033f02aa434fb03a8b190600a5ae4102df1fd",
-                "sha256:ce7866f29d3025b5b34c2e944e66ebef0d92e4a4f2463f7266daa03a1332a651",
-                "sha256:e26c993bd4b220429d4ec8c1468eca445a4064a61c74ca08da7429af9bc53bb0"
+                "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
+                "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259",
+                "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9",
+                "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097",
+                "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0",
+                "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f",
+                "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7",
+                "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c",
+                "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5",
+                "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7",
+                "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729",
+                "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978",
+                "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9",
+                "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f",
+                "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9",
+                "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822",
+                "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418",
+                "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82",
+                "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f",
+                "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d",
+                "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221",
+                "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4",
+                "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21",
+                "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709",
+                "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54",
+                "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d",
+                "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270",
+                "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24",
+                "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751",
+                "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a",
+                "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237",
+                "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7",
+                "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
+                "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==5.2.1"
+            "version": "==5.3"
         },
         "factory-boy": {
             "hashes": [
@@ -578,11 +585,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:bc4b8c908dfcd84e4fe5d9fa2e52fbe17546515fb8f126909b98c47badf05658",
-                "sha256:ff188c416864e3f7d8becd8f9ee683a4b4101a2a2d2bcdcb3e84bb1bdd06eaae"
+                "sha256:075a95ac4c95765370919d787dcd958acfaea635005ad5af4d926cb0973800db",
+                "sha256:80bab8d46035a7393de827210c5d39c17109d3346d131946bde622137120c496"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==4.1.2"
+            "version": "==4.1.3"
         },
         "flake8": {
             "hashes": [
@@ -616,11 +623,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:92533892058de0306e51c88f22ece002a209dc8e80288aa3cec6d443060d584f",
-                "sha256:a200d47b7ee8b7f7d0a9646650160c4a51b6a91a9413fd31b1da2c4de789f5d3"
+                "sha256:171c5f365791073426b5ed3a156c2081a47f88c329161fd28228ff2da4c97ddb",
+                "sha256:ba91218eee31f1e300ecc079ef0c524cea3fc41bfbb979cbdf5fd3a889e3cfed"
             ],
             "index": "pypi",
-            "version": "==5.5.1"
+            "version": "==5.5.2"
         },
         "jinja2": {
             "hashes": [
@@ -806,16 +813,16 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4",
-                "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"
+                "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40",
+                "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"
             ],
             "index": "pypi",
-            "version": "==6.0.1"
+            "version": "==6.0.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -827,11 +834,11 @@
         },
         "pytest-django": {
             "hashes": [
-                "sha256:64f99d565dd9497af412fcab2989fe40982c1282d4118ff422b407f3f7275ca5",
-                "sha256:664e5f42242e5e182519388f01b9f25d824a9feb7cd17d8f863c8d776f38baf9"
+                "sha256:4de6dbd077ed8606616958f77655fed0d5e3ee45159475671c7fa67596c6dba6",
+                "sha256:c33e3d3da14d8409b125d825d4e74da17bb252191bf6fc3da6856e27a8b73ea4"
             ],
             "index": "pypi",
-            "version": "==3.9.0"
+            "version": "==3.10.0"
         },
         "pytest-mock": {
             "hashes": [
@@ -937,11 +944,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:1a336d2b829be50e46b84668691e0a2719f26c97c62846298dd5ae2937e4d5cf",
-                "sha256:564d632ea2b9cb52979f7956e093e831c28d441c11751682f84c86fc46e4fd21"
+                "sha256:8f3c5815e3b5e20bc40463fa6b42a352178859692a68ffaa469706e6d38342a5",
+                "sha256:faf9c671bd3fad5ebaeee366949d969dca2b2be32c872a7092a1e1a9048d105b"
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.48.2"
+            "version": "==4.49.0"
         },
         "typed-ast": {
             "hashes": [

--- a/tdrs-backend/docker/Dockerfile.dev
+++ b/tdrs-backend/docker/Dockerfile.dev
@@ -11,6 +11,13 @@ ENV DJANGO_CONFIGURATION=Development
 # Allows docker to cache installed dependencies between builds
 COPY Pipfile Pipfile.lock /tdpapp/
 WORKDIR /tdpapp/
+# Download latest listing of available packages:
+RUN apt-get -y update
+# Upgrade already installed packages:
+RUN apt-get -y upgrade
+# Install a new package:
+RUN apt-get install -y gcc && apt-get install -y graphviz && apt-get install -y graphviz-dev
+# Install pipenv
 RUN pip install --upgrade pip pipenv && pipenv install --dev --system --deploy
 
 # Adds our application code to the image

--- a/tdrs-backend/docker/Dockerfile.dev
+++ b/tdrs-backend/docker/Dockerfile.dev
@@ -11,13 +11,6 @@ ENV DJANGO_CONFIGURATION=Development
 # Allows docker to cache installed dependencies between builds
 COPY Pipfile Pipfile.lock /tdpapp/
 WORKDIR /tdpapp/
-# Download latest listing of available packages:
-RUN apt-get -y update
-# Upgrade already installed packages:
-RUN apt-get -y upgrade
-# Install a new package:
-RUN apt-get install -y gcc && apt-get install -y graphviz && apt-get install -y graphviz-dev
-# Install pipenv
 RUN pip install --upgrade pip pipenv && pipenv install --dev --system --deploy
 
 # Adds our application code to the image

--- a/tdrs-backend/docker/Dockerfile.local
+++ b/tdrs-backend/docker/Dockerfile.local
@@ -10,6 +10,13 @@ ENV DJANGO_CONFIGURATION=Local
 # Allows docker to cache installed dependencies between builds
 COPY Pipfile Pipfile.lock /tdpapp/
 WORKDIR /tdpapp/
+# Download latest listing of available packages:
+RUN apt-get -y update
+# Upgrade already installed packages:
+RUN apt-get -y upgrade
+# Install a new package:
+RUN apt-get install -y gcc && apt-get install -y graphviz && apt-get install -y graphviz-dev
+# Install pipenv
 RUN pip install --upgrade pip pipenv && pipenv install --dev --system --deploy
 
 # Adds our application code to the image

--- a/tdrs-backend/docs/generating_an_erd.md
+++ b/tdrs-backend/docs/generating_an_erd.md
@@ -1,0 +1,29 @@
+# Graph Models ERD
+
+**Description**
+
+In order to produce an ERD of the current database architecture, we have introduced GraphViz and a suite of Python tools to automatically generate one.
+
+This was done using the Django Extension [Graph Models](https://django-extensions.readthedocs.io/en/latest/graph_models.html#graph-models)
+
+In order to generate an ERD, first navigate the root of the backend codebase (from the project root)
+
+```
+cd tdrs-backend
+```
+
+Next, run the project locally:
+
+```
+docker-compose up -d --build
+```
+Once the project is running, run the following command:
+```
+docker-compose run web sh -c "python manage.py graph_models --pygraphviz -a -g -o tdp-erd.png"
+```
+
+Lastly, open the file
+
+```
+open tdp-erd.png
+```

--- a/tdrs-backend/requirements.txt
+++ b/tdrs-backend/requirements.txt
@@ -3,8 +3,8 @@ appdirs==1.4.4
 appnope==0.1.0; sys_platform == 'darwin'
 asgiref==3.2.10; python_version >= '3.5'
 backcall==0.2.0
-boto3==1.14.58
-botocore==1.17.58
+boto3==1.14.63
+botocore==1.17.63
 certifi==2020.6.20
 cffi==1.14.2
 chardet==3.0.4
@@ -16,7 +16,7 @@ django-cors-headers==3.5.0
 django-extensions==3.0.8
 django-filter==2.3.0
 django-model-utils==4.0.0
-django-storages==1.10
+django-storages==1.10.1
 django-unique-upload==0.2.1
 django==3.1.1
 djangorestframework==3.11.1
@@ -38,8 +38,10 @@ psycopg2-binary==2.8.6
 ptpython==3.0.5
 ptyprocess==0.6.0
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pygments==2.6.1; python_version >= '3.5'
+pydot==1.4.1
+pygments==2.7.1; python_version >= '3.5'
 pyjwt==1.7.1
+pyparsing==2.4.7
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-dotenv==0.14.0
 pytz==2020.1

--- a/tdrs-backend/requirements.txt
+++ b/tdrs-backend/requirements.txt
@@ -3,8 +3,8 @@ appdirs==1.4.4
 appnope==0.1.0; sys_platform == 'darwin'
 asgiref==3.2.10; python_version >= '3.5'
 backcall==0.2.0
-boto3==1.14.63
-botocore==1.17.63
+boto3==1.15.0
+botocore==1.18.0
 certifi==2020.6.20
 cffi==1.14.2
 chardet==3.0.4
@@ -13,14 +13,13 @@ decorator==4.4.2
 dj-database-url==0.5.0
 django-configurations==2.2
 django-cors-headers==3.5.0
-django-extensions==3.0.8
+django-extensions==3.0.9
 django-filter==2.3.0
 django-model-utils==4.0.0
 django-storages==1.10.1
 django-unique-upload==0.2.1
 django==3.1.1
 djangorestframework==3.11.1
-docutils==0.15.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 gunicorn==20.0.4
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 ipdb==0.13.3
@@ -38,10 +37,8 @@ psycopg2-binary==2.8.6
 ptpython==3.0.5
 ptyprocess==0.6.0
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pydot==1.4.1
 pygments==2.7.1; python_version >= '3.5'
 pyjwt==1.7.1
-pyparsing==2.4.7
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-dotenv==0.14.0
 pytz==2020.1
@@ -50,5 +47,5 @@ s3transfer==0.3.3
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sqlparse==0.3.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 traitlets==5.0.4; python_version >= '3.7'
-urllib3==1.25.10; python_version != '3.4'
+urllib3==1.25.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
 wcwidth==0.2.5

--- a/tdrs-backend/tdpservice/settings/development.py
+++ b/tdrs-backend/tdpservice/settings/development.py
@@ -43,3 +43,9 @@ class Development(Common):
     AWS_HEADERS = {
         "Cache-Control": "max-age=86400, s-maxage=86400, must-revalidate",
     }
+
+    # Graph Models for GraphViz
+    GRAPH_MODELS = {
+        'all_applications': True,
+        'group_models': True,
+    }


### PR DESCRIPTION
Closes #253 

### This pull request changes...

- You can now generate an ERD in the local environment
- Instructions added under docs/generating_an_erd.md

### [AC] This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] Vulnerability Scan Test (Zap) has no high/critcial CVEs
- [x] Linting Tests (ESLint for UI and Flake8 for Python)
- [x] Unit Tests ( including a code coverage test report)
- [x] Accessibility Tests (Pa11y UI Only)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [x] Changelog is updated as appropriate


### [DoD] This feature is done when...

- [x] Design has approved the experience
- [x] Product has approved the experience
