### PR TITLE
Adjust the memory allowance of the backend app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
               export CF_PASSWORD="$CF_PASSWORD_DEV"
               export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_DEV"
               export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_DEV"
-            elif [ "$CIRCLE_BRANCH" == "raft-tdp-main" ] ; then
+            elif [ "$CIRCLE_BRANCH" == "cloudgov-backend-mem-increase" ] ; then
               export CF_SPACE="tanf-dev"
               export CF_USERNAME="$CF_USERNAME_DEV"
               export CF_PASSWORD="$CF_PASSWORD_DEV"
@@ -158,4 +158,4 @@ workflows:
           filters:
             branches:
               only:
-                - raft-tdp-main
+                - cloudgov-backend-mem-increase

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
               export CF_PASSWORD="$CF_PASSWORD_DEV"
               export CGHOSTNAME_BACKEND="$CGHOSTNAME_BACKEND_DEV"
               export CGHOSTNAME_FRONTEND="$CGHOSTNAME_FRONTEND_DEV"
-            elif [ "$CIRCLE_BRANCH" == "cloudgov-backend-mem-increase" ] ; then
+            elif [ "$CIRCLE_BRANCH" == "raft-tdp-main" ] ; then
               export CF_SPACE="tanf-dev"
               export CF_USERNAME="$CF_USERNAME_DEV"
               export CF_PASSWORD="$CF_PASSWORD_DEV"
@@ -158,4 +158,4 @@ workflows:
           filters:
             branches:
               only:
-                - cloudgov-backend-mem-increase
+                - raft-tdp-main

--- a/tdrs-backend/manifest.yml
+++ b/tdrs-backend/manifest.yml
@@ -1,7 +1,7 @@
 version: 1
 applications:
 - name: tdp-backend
-  memory: 1024M
+  memory: 1G
   instances: 1
   disk_quota: 2G
   docker:

--- a/tdrs-backend/manifest.yml
+++ b/tdrs-backend/manifest.yml
@@ -1,7 +1,7 @@
 version: 1
 applications:
 - name: tdp-backend
-  memory: 512M
+  memory: 1024M
   instances: 1
   disk_quota: 2G
   docker:

--- a/tdrs-backend/manifest.yml
+++ b/tdrs-backend/manifest.yml
@@ -1,8 +1,8 @@
 version: 1
 applications:
 - name: tdp-backend
-  memory: 2G
+  memory: 256M
   instances: 1
-  disk_quota: 3G
+  disk_quota: 2G
   docker:
     image: ((docker-backend))

--- a/tdrs-backend/manifest.yml
+++ b/tdrs-backend/manifest.yml
@@ -1,8 +1,8 @@
 version: 1
 applications:
 - name: tdp-backend
-  memory: 1G
+  memory: 2G
   instances: 1
-  disk_quota: 2G
+  disk_quota: 3G
   docker:
     image: ((docker-backend))


### PR DESCRIPTION
### This pull request changes...

Adjust the memory quota allowance for the cloud.gov instance of the backend application to resolve the following deployment error:

```
memory quota_exceeded
FAILED
```


Evidence the decreased memory allocation  resolved the error : 

https://app.circleci.com/pipelines/github/raft-tech/TANF-app/701/workflows/cc72b6b1-8434-403b-ae5b-5d9a02306fa1/jobs/1295