### PR TITLE
Sprint 5 fixes

### DIFF
--- a/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
+++ b/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
@@ -14,7 +14,7 @@ const ComboBox = ({ children }) => {
   return (
     <label className="usa-label" htmlFor="sttList">
       Associated State, Tribe, or Territory
-      <div className="usa-combo-box">
+      <div className="usa-combo-box" data-placeholder="- Select or Search -">
         <select className="usa-select" name="stt" id="stt" ref={selectRef}>
           {children}
         </select>

--- a/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
+++ b/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import comboBox from 'uswds/src/js/components/combo-box'
 
-const ComboBox = ({ sttList }) => {
+const ComboBox = ({ children }) => {
   const selectRef = useRef()
   useEffect(() => {
     // The combo box was not rendering as a combo box without this line
@@ -16,15 +16,7 @@ const ComboBox = ({ sttList }) => {
       Associated State, Tribe, or Territory
       <div className="usa-combo-box">
         <select className="usa-select" name="stt" id="stt" ref={selectRef}>
-          {sttList.map((stt) => (
-            <option
-              className="sttOption"
-              key={stt.id}
-              value={stt.name.toLowerCase()}
-            >
-              {stt.name}
-            </option>
-          ))}
+          {children}
         </select>
       </div>
     </label>
@@ -32,12 +24,10 @@ const ComboBox = ({ sttList }) => {
 }
 
 ComboBox.propTypes = {
-  sttList: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string,
-      id: PropTypes.number,
-    })
-  ).isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
 }
 
 export default ComboBox

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -44,7 +44,17 @@ function EditProfile() {
             aria-required="true"
           />
         </label>
-        <ComboBox sttList={stts} />
+        <ComboBox>
+          {stts.map((stt) => (
+            <option
+              className="sttOption"
+              key={stt.id}
+              value={stt.name.toLowerCase()}
+            >
+              {stt.name}
+            </option>
+          ))}
+        </ComboBox>
         <Button
           type="submit"
           disabled

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-// import comboBox from 'uswds/src/js/components/combo-box'
 import { fetchStts } from '../../actions/stts'
 import Button from '../Button'
 import ComboBox from '../ComboBox'

--- a/tdrs-frontend/src/components/GovBanner/GovBanner.jsx
+++ b/tdrs-frontend/src/components/GovBanner/GovBanner.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import smallFlag from 'uswds/dist/img/us_flag_small.png'
 import govLogo from 'uswds/dist/img/icon-dot-gov.svg'
 import httpsLogo from 'uswds/dist/img/icon-https.svg'


### PR DESCRIPTION
### This pull request changes...

- This adds the Placeholder to the Combo Box to meet AC
- This removes the `/stts/tests.py` from the backend. It became unneeded after moving tests to `/stts/test/`

### [AC] This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] Vulnerability Scan Test (Zap) has no high/critcial CVEs
- [ ] Linting Tests (ESLint for UI and Flake8 for Python)
- [ ] Unit Tests ( including a code coverage test report)
- [ ] Accessibility Tests (Pa11y UI Only)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate


### [DoD] This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
