### PR TITLE
230 form validation

### DIFF
--- a/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
+++ b/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
@@ -45,13 +45,9 @@ const ComboBox = ({
 
   return (
     <label className="usa-label" htmlFor={name.toUpperCase()}>
-      Associated State, Tribe, or Territory
+      Associated State, Tribe, or Territory (required)
       {error && (
-        <span
-          className="usa-error-message"
-          id={`${name}-error-message`}
-          role="alert"
-        >
+        <span className="usa-error-message" id={`${name}-error-message`}>
           {error}
         </span>
       )}

--- a/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
+++ b/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
@@ -49,7 +49,7 @@ const ComboBox = ({
       {error && (
         <span
           className="usa-error-message"
-          id="input-error-message"
+          id={`${name}-error-message`}
           role="alert"
         >
           {error}

--- a/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
+++ b/tdrs-frontend/src/components/ComboBox/ComboBox.jsx
@@ -44,7 +44,10 @@ const ComboBox = ({
   })
 
   return (
-    <label className="usa-label" htmlFor={name.toUpperCase()}>
+    <label
+      className={`usa-label ${error ? 'usa-label--error' : ''}`}
+      htmlFor={name.toUpperCase()}
+    >
       Associated State, Tribe, or Territory (required)
       {error && (
         <span className="usa-error-message" id={`${name}-error-message`}>

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -106,7 +106,7 @@ function EditProfile() {
     )
     setErrors(formValidation.errors)
     setTouched(formValidation.touched)
-    setTimeout(() => errorRef.current.focus(), 10)
+    setTimeout(() => errorRef.current.focus(), 0)
   }
 
   return (

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -130,7 +130,7 @@ function EditProfile() {
             {errors.firstName && (
               <span
                 className="usa-error-message"
-                id="firstName-error-message"
+                id="first-name-error-message"
                 role="alert"
               >
                 {errors.firstName}
@@ -165,7 +165,7 @@ function EditProfile() {
             {errors.lastName && (
               <span
                 className="usa-error-message"
-                id="lastName-error-message"
+                id="last-name-error-message"
                 role="alert"
               >
                 {errors.lastName}

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -126,7 +126,7 @@ function EditProfile() {
             }`}
             htmlFor="firstName"
           >
-            First name
+            First Name
             {errors.firstName && (
               <span
                 className="usa-error-message"
@@ -161,7 +161,7 @@ function EditProfile() {
             className={`usa-label ${errors.lastName ? 'usa-label--error' : ''}`}
             htmlFor="lastName"
           >
-            Last name
+            Last Name
             {errors.lastName && (
               <span
                 className="usa-error-message"

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchStts } from '../../actions/stts'
 import Button from '../Button'
@@ -43,6 +43,7 @@ export const validation = (fieldName, fieldValue) => {
  *  an associated STT.
  */
 function EditProfile() {
+  const errorRef = useRef(null)
   const stts = useSelector((state) => state.stts.stts)
   const dispatch = useDispatch()
 
@@ -105,16 +106,29 @@ function EditProfile() {
     )
     setErrors(formValidation.errors)
     setTouched(formValidation.touched)
+    setTimeout(() => errorRef.current.focus(), 10)
   }
 
   return (
     <div className="grid-container">
       <h1 className="request-access-header font-serif-2xl">Request Access</h1>
       <p className="request-access-secondary">
-        We need to collect some information before an OFA Admin can grant you
-        access
+        Please enter your information to request access from an OFA
+        administrator
       </p>
       <form className="usa-form" onSubmit={handleSubmit}>
+        <div
+          className={`usa-error-message ${
+            !!Object.keys(errors).length && !!Object.keys(touched).length
+              ? 'display-block'
+              : 'display-none'
+          }`}
+          ref={errorRef}
+          tabIndex="-1"
+          role="alert"
+        >
+          There are {Object.keys(errors).length} errors in this form
+        </div>
         <div
           className={`usa-form-group ${
             errors.firstName ? 'usa-form-group--error' : ''
@@ -126,13 +140,9 @@ function EditProfile() {
             }`}
             htmlFor="firstName"
           >
-            First Name
+            First Name (required)
             {errors.firstName && (
-              <span
-                className="usa-error-message"
-                id="first-name-error-message"
-                role="alert"
-              >
+              <span className="usa-error-message" id="first-name-error-message">
                 {errors.firstName}
               </span>
             )}
@@ -161,13 +171,9 @@ function EditProfile() {
             className={`usa-label ${errors.lastName ? 'usa-label--error' : ''}`}
             htmlFor="lastName"
           >
-            Last Name
+            Last Name (required)
             {errors.lastName && (
-              <span
-                className="usa-error-message"
-                id="last-name-error-message"
-                role="alert"
-              >
+              <span className="usa-error-message" id="last-name-error-message">
                 {errors.lastName}
               </span>
             )}

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.jsx
@@ -130,7 +130,7 @@ function EditProfile() {
             {errors.firstName && (
               <span
                 className="usa-error-message"
-                id="input-error-message"
+                id="firstName-error-message"
                 role="alert"
               >
                 {errors.firstName}
@@ -165,7 +165,7 @@ function EditProfile() {
             {errors.lastName && (
               <span
                 className="usa-error-message"
-                id="input-error-message"
+                id="lastName-error-message"
                 role="alert"
               >
                 {errors.lastName}

--- a/tdrs-frontend/src/components/EditProfile/EditProfile.test.js
+++ b/tdrs-frontend/src/components/EditProfile/EditProfile.test.js
@@ -174,9 +174,9 @@ describe('EditProfile', () => {
 
     const errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(3)
-    expect(errorMessages.first().text()).toEqual('First Name is required')
-    expect(errorMessages.at(1).text()).toEqual('Last Name is required')
+    expect(errorMessages.length).toEqual(4)
+    expect(errorMessages.at(1).text()).toEqual('First Name is required')
+    expect(errorMessages.at(2).text()).toEqual('Last Name is required')
     expect(errorMessages.last().text()).toEqual(
       'A state, tribe, or territory is required'
     )
@@ -222,7 +222,7 @@ describe('EditProfile', () => {
 
     let errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(3)
+    expect(errorMessages.length).toEqual(4)
 
     const firstNameInput = wrapper.find('#firstName')
 
@@ -237,7 +237,7 @@ describe('EditProfile', () => {
 
     errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(2)
+    expect(errorMessages.length).toEqual(3)
 
     const lastNameInput = wrapper.find('#lastName')
 
@@ -252,7 +252,8 @@ describe('EditProfile', () => {
 
     errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(1)
+    expect(errorMessages.length).toEqual(2)
+    expect(errorMessages.first().hasClass('display-none')).toEqual(false)
 
     const select = wrapper.find('.usa-select')
 
@@ -265,7 +266,8 @@ describe('EditProfile', () => {
 
     errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(0)
+    expect(errorMessages.length).toEqual(1)
+    expect(errorMessages.first().hasClass('display-none')).toEqual(true)
   })
 
   it("should return 'First Name is required' if fieldName is firstName and fieldValue is empty", () => {
@@ -298,7 +300,7 @@ describe('EditProfile', () => {
     expect(error).toEqual(null)
   })
 
-  it('should display an error message when the input has` been touched', () => {
+  it('should display an error message when the input has been touched', () => {
     const store = mockStore({
       ...initialState,
       stts: {
@@ -338,7 +340,7 @@ describe('EditProfile', () => {
 
     let errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(3)
+    expect(errorMessages.length).toEqual(4)
 
     const firstNameInput = wrapper.find('#firstName')
 
@@ -353,7 +355,7 @@ describe('EditProfile', () => {
 
     errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(2)
+    expect(errorMessages.length).toEqual(3)
 
     firstNameInput.simulate('change', {
       target: {
@@ -366,7 +368,7 @@ describe('EditProfile', () => {
 
     errorMessages = wrapper.find('.usa-error-message')
 
-    expect(errorMessages.length).toEqual(3)
+    expect(errorMessages.length).toEqual(4)
   })
 
   it('should set the Select element value to the value of the event when there is a selected stt', () => {


### PR DESCRIPTION
### This pull request changes...

- Add dynamic `usa-label--error`
- Add errorRef to add focus functionality on errors for accessibility
- Update EditProfile copy
- Add separate error section with the total number of errors
- Add `required` to labels on EditProfile per accessibility review from Robert Jolly
- Update tests

### This pull request is ready to merge when...

- [ ] Meets acceptance criteria for the issue 
- [ ] Code is reviewed by someone other than the original author
- [ ] Code is tested 
- [ ] Experience is approved by UX  
- [ ] Meets [a11y checklist](https://github.com/HHS/TANF-app/blob/main/docs/a11y/how-18f-will-test-a11y.md)
- [ ] Meets [Raft's Manual QASP Checklist](https://teams.microsoft.com/l/file/B5285301-13CA-46FD-A723-AFFD578C224A?tenantId=d58addea-5053-4a80-8499-ba4d944910df&fileType=docx&objectUrl=https%3A%2F%2Fhhsgov.sharepoint.com%2Fsites%2FTANFDataPortalOFA%2FShared%20Documents%2FGeneral%2FManual%20Testing%20Practices_Issue173.docx&baseUrl=https%3A%2F%2Fhhsgov.sharepoint.com%2Fsites%2FTANFDataPortalOFA&serviceName=teams&threadId=19:f769bbcb029f4f02b55ae7fad90e310d@thread.skype&groupId=41f194a6-c1d3-4680-933e-c8ee7d17e287):lock: (only applicable for PR to main HHS)
- [ ] Documentation is updated 
  - OpenAPI  
  - Readme
  - Entity Relationship Diagram (ERD)
