### PR TITLE
Hotfix: Resolve vendor staging deployment issue introduced by clamav-rest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,11 +170,11 @@ jobs:
             cf auth "$CF_USERNAME" "$CF_PASSWORD"
             cf target -o $CF_ORG -s "$CF_SPACE"
 
-            # Deploy ClamAV REST server
             # First delete the existing implementation of clamav-rest so we don't exhaust memory quota
             cf delete -r clamav-rest -f
-            # NOTE: docker-backend is unused by clamav-rest but is needed to prevent an error when calling cf push
-            cf push clamav-rest -f tdrs-backend/manifest.yml --var docker-backend=null --var cf-space=$CF_SPACE
+
+            # Deploy ClamAV REST server
+            cf push clamav-rest -f tdrs-backend/manifest_clamav.yml --var cf-space=$CF_SPACE
 
             # Deploy frontend and backend applications
             ./deploy-cloudgov-docker.sh rolling test $CGHOSTNAME_BACKEND $CGHOSTNAME_FRONTEND $DOCKER_IMAGE_BACKEND $DOCKER_IMAGE_FRONTEND $CIRCLE_BRANCH $CF_SPACE

--- a/tdrs-backend/manifest.yml
+++ b/tdrs-backend/manifest.yml
@@ -8,13 +8,3 @@ applications:
     image: ((docker-backend))
   env:
     AV_SCAN_URL: http://((cf-space))-clamav-rest.apps.internal:9000/scan
-- name: clamav-rest
-  instances: 1
-  memory: 2G
-  disk_quota: 2G
-  docker:
-    image: rafttech/clamav-rest:0.103.2
-  env:
-    MAX_FILE_SIZE: 200M
-  routes:
-  - route: ((cf-space))-clamav-rest.apps.internal

--- a/tdrs-backend/manifest_clamav.yml
+++ b/tdrs-backend/manifest_clamav.yml
@@ -1,0 +1,12 @@
+version: 1
+applications:
+- name: clamav-rest
+  instances: 1
+  memory: 2G
+  disk_quota: 2G
+  docker:
+    image: rafttech/clamav-rest:0.103.2
+  env:
+    MAX_FILE_SIZE: 200M
+  routes:
+    - route: ((cf-space))-clamav-rest.apps.internal


### PR DESCRIPTION
### Summary of Changes
Resolves deployment failure introduced with #817 

Currently when we call the `cf push` command to deploy the backend we pass in the app name as the `CGHOSTNAME_BACKEND` variable from Circle CI. This does not necessarily always match the app name defined in our `manifest.yml` but was previously working anyway due to there only being one application defined in the manifest file.

With https://github.com/raft-tech/TANF-app/pull/819 a second application was introduced to the manifest file for clamav-rest. This didn't show any issues during testing because the `CGHOSTNAME_BACKEND` was set to `tdp-backend` - which matches the manifest file. However, commits to `raft-tdp-main` result in deployments that point to vendor staging (currently) - which equates to an app name of `tdp-backend-vendor-staging`. Since there was now multiple applications in the manifest and none of them match that app name the `cf push` now fails when running against vendor staging.

By separating out the clamav-rest application into its own manifest file we can target it separately with a `cf push` command and everything else will work the way it did previously.

### How to Test
* Install the Cloud Foundry CLI if it isn't already installed
* Set API endpoint to cloud.gov's target:
```
cf api https://api.fr.cloud.gov 
```
* Run login command:
```
cf login --sso
```
* Using the link provided from the command above login with SSO:
```                                                                                                                                                                                        
API endpoint: https://api.fr.cloud.gov

Temporary Authentication Code ( Get one at https://login.fr.cloud.gov/passcode ): 
Authenticating...
OK
```
* Ensure you are targeting the right space/org, and change it if not. The output from the login command should look like this if so:
```
Targeted org hhs-acf-prototyping.

Targeted space tanf-dev.
```
* Re-deploy clamav-rest using the new manifest
```
cf delete -r clamav-rest -f
cf push clamav-rest -f tdrs-backend/manifest_clamav.yml --var cf-space=tanf-dev 
```
* Run deploy script with vendor staging arguments:
```
./deploy-cloudgov-docker.sh rolling test tdp-backend-vendor-staging tdp-frontend-vendor-staging lfrohlich/tdp-backend:raft-tdp-main lfrohlich/tdp-frontend:raft-tdp-main raft-tdp-main tanf-dev
```
* Add network policy:
```
cf add-network-policy tdp-backend-vendor-staging clamav-rest -s tanf-dev -o hhs-acf-prototyping --protocol tcp --port 9000 
```
If all of those commands executed successfully check out the deployed instance and confirm in Cloud.gov everything is available (including clamav-rest).
