### PR TITLE
Update erd job to run on develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,7 +609,7 @@ workflows:
          filters:
              branches:
                  only:
-                     raft-tdp-main
+                     develop
 
   owasp-scan:
     when: << pipeline.parameters.run_owasp_scan >>


### PR DESCRIPTION
## Summary of Changes

Updating erd job to run on `develop` branch (formerly `raft-tdp-main`)


