### PR TITLE
Updating cloud.gov org name and django settings ALLOWED_HOSTS for pro…

### DIFF
--- a/tdrs-backend/tdpservice/settings/cloudgov.py
+++ b/tdrs-backend/tdpservice/settings/cloudgov.py
@@ -136,7 +136,7 @@ class Production(CloudGov):
     """Settings for applications deployed in the Cloud.gov production space."""
 
     # TODO: Add production ACF domain when known
-    ALLOWED_HOSTS = ['tdp-backend-production.app.cloud.gov']
+    ALLOWED_HOSTS = ['api.tanfdata.acf.hhs.gov']
 
     LOGIN_GOV_CLIENT_ID = os.getenv(
         'OIDC_RP_CLIENT_ID',

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -13,7 +13,7 @@ variable "cf_api_url" {
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"
-  default     = "hhs-acf-prototyping"
+  default     = "hhs-acf-ofa"
 }
 
 variable "cf_space_name" {

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -13,7 +13,7 @@ variable "cf_api_url" {
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"
-  default     = "hhs-acf-prototyping"
+  default     = "hhs-acf-ofa"
 }
 
 variable "cf_space_name" {

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -13,7 +13,7 @@ variable "cf_api_url" {
 variable "cf_org_name" {
   type        = string
   description = "cloud.gov organization name"
-  default     = "hhs-acf-prototyping"
+  default     = "hhs-acf-ofa"
 }
 
 variable "cf_space_name" {


### PR DESCRIPTION
## Summary of Changes
Per #895 task for updating `ALLOWED_HOSTS` as well as Sunday's update to our Cloud.gov organization name, we'll need to make some minor updates which are being captured in this PR. Note that the merge target is @jorgegonzalez 's testing branch from PR #1764 .