### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/tdrs-frontend"
     schedule:
       interval: "daily"
-    target-branch: "raft-tdp-main"
+    target-branch: "develop"
     labels:
       - "dependencies"
       - "frontend"
@@ -32,7 +32,7 @@ updates:
     directory: "/tdrs-backend"
     schedule:
       interval: "daily"
-    target-branch: "raft-tdp-main"
+    target-branch: "develop"
     labels:
       - "dependencies"
       - "backend"


### PR DESCRIPTION
## Summary of Changes
Dependabot config was still pointing at `raft-tdp-main` instead of develop. These configuration changes were missed in #1731 

## How to Test
N/A