### PR TITLE
clamav was getting network policies nuked every deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,15 +202,13 @@ commands:
         type: string
     steps:
       - run:
-          name: Delete existing ClamAV REST application
-          command: cf delete -r clamav-rest -f
-      - run:
           name: Deploy ClamAV REST application
           command: |
             cf push clamav-rest -f tdrs-backend/manifest.clamav.yml \
-              --var cf-space=<<parameters.cf-space>>
+              --var cf-space=<<parameters.cf-space>> \
+              --strategy rolling
       - run:
-          name: Enable internal route between backend and clamav-rest apps
+          name: Enable internal route between backend and clamav-rest app
           command: |
             cf add-network-policy <<parameters.backend-appname>> clamav-rest \
               -s <<parameters.cf-space>> \


### PR DESCRIPTION
## Summary of Changes
Looking at the pull request for #881, John had mentioned that we were hitting a memory quota limit when using the rolling strategy so we were deleting/recreating the clamav instance. Instead, we will be using the rolling strategy now so because this quota is not an issue now.

Additionally, the network policy after deployment would only be set for the latest. I have manually added all 4 dev spaces to be able to communicate here, so this should now persist through a deployment. If we ever have to delete clamav, we will have to manually re-add these until we can sufficiently terraform our way our of this.