### PR TITLE
bug/fix-cf-install-for-circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,7 @@ commands:
             apk update
             apk add jq
             apk add curl
+            # TODO: Add Signature check
             curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | tar -zx
             mv cf7 /usr/local/bin/cf
       - login-cloud-dot-gov:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,9 @@ commands:
           command: |
             apk update
             apk add jq
-            apk add cloudfoundry-cli --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+            apk add curl
+            curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | tar -zx
+            mv cf7 /usr/local/bin/cf
       - login-cloud-dot-gov:
           cf-password: <<parameters.cf-password>>
           cf-username: <<parameters.cf-username>>


### PR DESCRIPTION
On 7/15 we noticed that the build dependency step in CircleCi was breaking on all branches due to this error:

![Screen Shot 2022-07-15 at 11 53 21 AM](https://user-images.githubusercontent.com/7119690/179292080-17d7ff1d-4f22-400c-bd22-525183d57fad.png)

@riatzukiza and I examined it and decided to try installing cloudfoundry-cli from source instead of using apk. Doing it this way will avoid the problem with verifying the signature.

After changing the CircleCi script it worked. 
![Screen Shot 2022-07-15 at 11 56 51 AM](https://user-images.githubusercontent.com/7119690/179292628-912c80dd-b380-4217-9a95-fe0bcbbe28b8.png)

