### PR TITLE
Corrects hrefs still looking for jpegs instead of jpgs

### DIFF
--- a/product-updates/knowledge-center/complete-resubmissions.html
+++ b/product-updates/knowledge-center/complete-resubmissions.html
@@ -269,8 +269,8 @@
 <br>
             <p class="margin-top-05">
               This will typically involve selecting the appropriate year, month, and case number to retrieve and making edits to fields that are associated with the edit code in your transmission email report.<div style="min-height: 22px;"></div>
-            <a href="../img/complete-data/step1.jpeg" data-lity data-lity-desc="fTANF.exe opened to TANF Cases > Active with a chosen year, month, and case number.">
-            <img src="../img/complete-data/step1.jpeg" alt="fTANF.exe opened to TANF Cases > Active with a chosen year, month, and case number.">
+            <a href="../img/complete-data/step1.jpg" data-lity data-lity-desc="fTANF.exe opened to TANF Cases > Active with a chosen year, month, and case number.">
+            <img src="../img/complete-data/step1.jpg" alt="fTANF.exe opened to TANF Cases > Active with a chosen year, month, and case number.">
               </a>
             </p>
           </li>
@@ -285,12 +285,12 @@
               <li>Click the “Global Warning Edits” button to check all records for fatal errors. At the end of this step, all cases for the specified month should have an Edit Status of “Passed all edits”.</li>
               </ul>
               <p>These steps should be repeated for each month in the quarterly Section 1 or Section 2 file.</p><br>
-              <a href="../img/complete-data/Step2.jpeg" data-lity data-lity-desc="fTANF.exe opened to Utilities > Case Management with Global Fatal Edits, Global Warning Edits, and Reset Transmission Flag annotated as steps 1, 2, and 3.">
-              <img src="../img/complete-data/Step2.jpeg" alt="fTANF.exe opened to Utilities > Case Management with Global Fatal Edits, Global Warning Edits, and Reset Transmission Flag annotated as steps 1, 2, and 3.">
+              <a href="../img/complete-data/Step2.jpg" data-lity data-lity-desc="fTANF.exe opened to Utilities > Case Management with Global Fatal Edits, Global Warning Edits, and Reset Transmission Flag annotated as steps 1, 2, and 3.">
+              <img src="../img/complete-data/Step2.jpg" alt="fTANF.exe opened to Utilities > Case Management with Global Fatal Edits, Global Warning Edits, and Reset Transmission Flag annotated as steps 1, 2, and 3.">
                 </a>
 
-              <a href="../img/complete-data/Step2-2.jpeg"  data-lity data-lity-desc="Cases in fTANF Case Management with the Edit Status of 'Not Edited' or 'Transmitted' will not be included when a new transmission file is created. All Cases that have the Edit Status of 'Passed All Edits' will be included when a new transmission file is created.">
-              <img src="../img/complete-data/Step2-2.jpeg" alt="Cases in fTANF Case Management with the Edit Status of 'Not Edited' or 'Transmitted' will not be included when a new transmission file is created. All Cases that have the Edit Status of 'Passed All Edits' will be included when a new transmission file is created.">
+              <a href="../img/complete-data/Step2-2.jpg"  data-lity data-lity-desc="Cases in fTANF Case Management with the Edit Status of 'Not Edited' or 'Transmitted' will not be included when a new transmission file is created. All Cases that have the Edit Status of 'Passed All Edits' will be included when a new transmission file is created.">
+              <img src="../img/complete-data/Step2-2.jpg" alt="Cases in fTANF Case Management with the Edit Status of 'Not Edited' or 'Transmitted' will not be included when a new transmission file is created. All Cases that have the Edit Status of 'Passed All Edits' will be included when a new transmission file is created.">
               </a>
             </p>
           </li>
@@ -299,8 +299,8 @@
             <h3 class="usa-process-list__heading">Navigate to the “Utilities” tab, and select the Transmission File Creation option to go through the process of generating an updated transmission file for the section, year, and quarter, for which corrections to data were made.</h3>
 <br>
             <p>One of the key attributes in this newly-generated file is the <strong>Update indicator</strong> which is part of the header record. This Indicator tells the legacy TANF system, TDRS (TANF Data Reporting System) whether a data file includes new (N-New) records, updated records that should be merged with existing data (U-Update), or records that should completely replace all previously-transmitted records for the section, year, and quarter (D-Delete).</p>
-            <a href="../img/complete-data/Step3.jpeg"  data-lity data-lity-desc="fTANF.exe opened to the transmission file creation screen with emphasis on the Update Indicator being set to 'Delete'.">
-            <img src="../img/complete-data/Step3.jpeg" alt="fTANF.exe opened to the transmission file creation screen with emphasis on the Update Indicator being set to 'Delete'.">
+            <a href="../img/complete-data/Step3.jpg"  data-lity data-lity-desc="fTANF.exe opened to the transmission file creation screen with emphasis on the Update Indicator being set to 'Delete'.">
+            <img src="../img/complete-data/Step3.jpg" alt="fTANF.exe opened to the transmission file creation screen with emphasis on the Update Indicator being set to 'Delete'.">
           </a>
             <p>To ensure that your data remains consistent between systems as we’re working to fully replace TDRS with TDP, we ask that you use the Delete value of the Update Indicator in all resubmissions. If you need to confirm that the Delete value has been set correctly, you can look for the “D” value at the end of the Header Record of the file you’re submitting (emphasized below).</p>
 

--- a/product-updates/knowledge-center/create-new-login.html
+++ b/product-updates/knowledge-center/create-new-login.html
@@ -248,8 +248,8 @@
             <p class="margin-top-05">
               Begin here: <a href="https://tanfdata.acf.hhs.gov/">Visit the TANF Data Portal</a> and select 'Sign in with login.gov for grantees'
               <div style="min-height: 22px;"></div>
-              <a href="../img/getting-started/existing-login-homepage.jpeg" data-lity data-lity-desc="TANF Data Portal Sign In Page">
-              <img src="../img/getting-started/existing-login-homepage.jpeg" alt="TANF Data Portal Sign In Page">
+              <a href="../img/getting-started/existing-login-homepage.jpg" data-lity data-lity-desc="TANF Data Portal Sign In Page">
+              <img src="../img/getting-started/existing-login-homepage.jpg" alt="TANF Data Portal Sign In Page">
                 </a>
             </p>
           </li>

--- a/product-updates/knowledge-center/existing-login.html
+++ b/product-updates/knowledge-center/existing-login.html
@@ -243,8 +243,8 @@
             <h2 class="usa-process-list__heading">Sign into the TANF Data Portal</h2>
             <p class="margin-top-05">
               Begin here: <a href="https://tanfdata.acf.hhs.gov/">Visit the TANF Data Portal</a> and select "Sign in with LOGIN.GOV for grantees"<div style="min-height: 22px;"></div>
-            <a href="../img/getting-started/existing-login-homepage.jpeg" data-lity data-lity-desc="TANF Data Portal Sign In Page">
-            <img src="../img/getting-started/existing-login-homepage.jpeg" alt="TANF Data Portal Sign In Page">
+            <a href="../img/getting-started/existing-login-homepage.jpg" data-lity data-lity-desc="TANF Data Portal Sign In Page">
+            <img src="../img/getting-started/existing-login-homepage.jpg" alt="TANF Data Portal Sign In Page">
               </a>
             </p>
           </li>


### PR DESCRIPTION
## Summary of Changes
Noticed that corrupted images accidentally got changed to missing images due to hrefs not changing to reflect file extension change for jpeg > jpg. This adds that final correction to the three affected pages (Complete Resubmissions, Creating a new login.gov account, using an existing login.gov account)

## How to Test
HTML difs for those three impacted pages can be inspected to confirm jpeg has become jpg

