### PR TITLE
Feat/1787 site map redo

### DIFF
--- a/tdrs-frontend/src/components/Footer/Footer.jsx
+++ b/tdrs-frontend/src/components/Footer/Footer.jsx
@@ -17,7 +17,7 @@ function Footer() {
                     className="usa-footer__primary-link"
                     href="https://www.acf.hhs.gov/privacy-policy"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     Privacy policy
                   </a>
@@ -28,7 +28,7 @@ function Footer() {
                       className="usa-footer__primary-link"
                       href="/site-map"
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                     >
                       Site Map
                     </a>

--- a/tdrs-frontend/src/components/Footer/Footer.jsx
+++ b/tdrs-frontend/src/components/Footer/Footer.jsx
@@ -20,6 +20,16 @@ function Footer() {
                     Privacy policy
                   </a>
                 </li>
+                <li className="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+                  <a
+                    className="usa-footer__primary-link"
+                    href="/site-map"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Site Map
+                  </a>
+                </li>
               </ul>
             </nav>
           </div>

--- a/tdrs-frontend/src/components/Footer/Footer.jsx
+++ b/tdrs-frontend/src/components/Footer/Footer.jsx
@@ -27,7 +27,7 @@ function Footer() {
                     <a
                       className="usa-footer__primary-link"
                       href="/site-map"
-                      target="_blank"
+                      target="_self"
                       rel="noopener noreferrer"
                     >
                       Site Map

--- a/tdrs-frontend/src/components/Footer/Footer.jsx
+++ b/tdrs-frontend/src/components/Footer/Footer.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 
 import ACFLogo from '../../assets/ACFLogo.svg'
 
 function Footer() {
+  const authenticated = useSelector((state) => state.auth.authenticated)
   return (
     <footer className="usa-footer usa-footer--slim">
       <div className="usa-footer__primary-section">
@@ -20,16 +22,18 @@ function Footer() {
                     Privacy policy
                   </a>
                 </li>
-                <li className="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
-                  <a
-                    className="usa-footer__primary-link"
-                    href="/site-map"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Site Map
-                  </a>
-                </li>
+                {authenticated ? (
+                  <li className="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content">
+                    <a
+                      className="usa-footer__primary-link"
+                      href="/site-map"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Site Map
+                    </a>
+                  </li>
+                ) : null}
               </ul>
             </nav>
           </div>

--- a/tdrs-frontend/src/components/Footer/Footer.test.js
+++ b/tdrs-frontend/src/components/Footer/Footer.test.js
@@ -1,16 +1,81 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+import configureStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { Provider } from 'react-redux'
 
 import Footer from './Footer'
+import { permissions } from '../Header/developer_permissions'
 
 describe('Footer', () => {
+
+  const unauthenticatedInitialState = {
+    router: { location: { pathname: '/profile' } },
+    auth: {
+      authenticated: false,
+    },
+  }
+  const adminInitialState = {
+    router: { location: { pathname: '/profile' } },
+    auth: {
+      authenticated: true,
+      roles: [{ id: 1, name: 'Developer', permissions }],
+    },
+  }
+
+  const basicAuthenticatedInitialState = {
+    router: { location: { pathname: '/profile' } },
+    auth: {authenticated: true},
+  }
+  const mockStore = configureStore([thunk])
   it('renders the children & families logo', () => {
-    const { container } = render(<Footer />)
+    const store = mockStore(unauthenticatedInitialState)
+    const { container } = render(
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    )
     expect(container.querySelector('img')).toBeInTheDocument()
   })
 
-  it('renders the privacy policy link', () => {
-    const { getByText } = render(<Footer />)
+  it('renders the privacy policy link as an unauthenticated user', () => {
+    const store = mockStore(unauthenticatedInitialState)
+    const { getByText } = render(
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    )
     expect(getByText('Privacy policy')).toBeInTheDocument()
   })
+
+  it('renders the privacy policy link as an authenticated user', () => {
+    const store = mockStore(basicAuthenticatedInitialState)
+    const { getByText } = render(
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    )
+    expect(getByText('Privacy policy')).toBeInTheDocument()
+  })
+
+  it('renders the site map link if a user is authenticated', () => {
+    const store = mockStore(basicAuthenticatedInitialState)
+    const { getByText } = render(
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    )
+    expect(getByText('Site Map')).toBeInTheDocument()
+  })
+
+  it('does not render the sitemap link if a user is not authenticated', () => {
+    const store = mockStore(unauthenticatedInitialState)
+    const { queryByText} = render(
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    )
+    expect(queryByText('Site Map')).not.toBeInTheDocument()
+  })
+
 })

--- a/tdrs-frontend/src/components/Footer/Footer.test.js
+++ b/tdrs-frontend/src/components/Footer/Footer.test.js
@@ -8,7 +8,6 @@ import Footer from './Footer'
 import { permissions } from '../Header/developer_permissions'
 
 describe('Footer', () => {
-
   const unauthenticatedInitialState = {
     router: { location: { pathname: '/profile' } },
     auth: {
@@ -25,7 +24,7 @@ describe('Footer', () => {
 
   const basicAuthenticatedInitialState = {
     router: { location: { pathname: '/profile' } },
-    auth: {authenticated: true},
+    auth: { authenticated: true },
   }
   const mockStore = configureStore([thunk])
   it('renders the children & families logo', () => {
@@ -70,12 +69,11 @@ describe('Footer', () => {
 
   it('does not render the sitemap link if a user is not authenticated', () => {
     const store = mockStore(unauthenticatedInitialState)
-    const { queryByText} = render(
+    const { queryByText } = render(
       <Provider store={store}>
         <Footer />
       </Provider>
     )
     expect(queryByText('Site Map')).not.toBeInTheDocument()
   })
-
 })

--- a/tdrs-frontend/src/components/Header/Header.jsx
+++ b/tdrs-frontend/src/components/Header/Header.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import closeIcon from 'uswds/dist/img/close.svg'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSignOutAlt, faUserCircle } from '@fortawesome/free-solid-svg-icons'
-import canViewAdmin from '../../utils/canViewAdmin'
+import { canViewAdmin } from '../../utils/canViewAdmin'
 
 import NavItem from '../NavItem/NavItem'
 

--- a/tdrs-frontend/src/components/Header/Header.jsx
+++ b/tdrs-frontend/src/components/Header/Header.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux'
 import closeIcon from 'uswds/dist/img/close.svg'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSignOutAlt, faUserCircle } from '@fortawesome/free-solid-svg-icons'
+import canViewAdmin from '../../utils/canViewAdmin'
 
 import NavItem from '../NavItem/NavItem'
 
@@ -21,20 +22,12 @@ function Header() {
   const user = useSelector((state) => state.auth.user)
   const authenticated = useSelector((state) => state.auth.authenticated)
   const userAccessRequestPending = Boolean(user?.['access_request'])
-  const userAccessRequestApproved =
-    Boolean(user?.['access_request']) && user.roles.length > 0
-
-  const isMemberOfOne = (...groupNames) =>
-    user?.roles?.some((role) => groupNames.includes(role.name))
 
   const hasPermission = (permissionName) =>
     user?.roles?.[0]?.permissions?.some(
       (perm) => perm.codename === permissionName
     )
 
-  const canViewAdmin =
-    userAccessRequestApproved &&
-    isMemberOfOne('Developer', 'OFA System Admin', 'ACF OCIO')
   const canViewDataFiles = hasPermission('view_datafile')
 
   const menuRef = useRef()
@@ -134,7 +127,7 @@ function Header() {
                       href="/profile"
                     />
                   )}
-                  {canViewAdmin && (
+                  {canViewAdmin(user) && (
                     <NavItem
                       pathname={pathname}
                       tabTitle="Admin"

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -6,6 +6,9 @@ import Profile from '../Profile'
 import PrivateRoute from '../PrivateRoute'
 import LoginCallback from '../LoginCallback'
 import Reports from '../Reports'
+
+import SiteMap from '../SiteMap'
+
 import Home from '../Home'
 import { useSelector } from 'react-redux'
 
@@ -44,6 +47,16 @@ const AppRoutes = () => {
         element={
           <PrivateRoute title="TANF Data Files">
             <Reports />
+          </PrivateRoute>
+        }
+      />
+
+      <Route
+        exact
+        path="/site-map"
+        element={
+          <PrivateRoute title="Site Map">
+            <SiteMap />
           </PrivateRoute>
         }
       />

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -6,6 +6,7 @@ import Profile from '../Profile'
 import PrivateRoute from '../PrivateRoute'
 import LoginCallback from '../LoginCallback'
 import Reports from '../Reports'
+import { useSelector } from 'react-redux'
 
 import SiteMap from '../SiteMap'
 
@@ -16,7 +17,10 @@ import Home from '../Home'
  * Routes have the 'exact' prop, so the order of routes
  * does not matter.
  */
-const AppRoutes = ({ user }) => {
+const AppRoutes = () => {
+  // The logged in user in our Redux state
+  const user = useSelector((state) => state.auth.user)
+
   const role = user?.roles
   const hasRole = Boolean(role?.length > 0)
 

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -10,10 +10,6 @@ import Reports from '../Reports'
 import SiteMap from '../SiteMap'
 
 import Home from '../Home'
-import { useSelector } from 'react-redux'
-
-const isMemberOfOne = (user, ...groupNames) =>
-  !!user?.roles?.some((role) => groupNames.includes(role.name))
 
 /**
  * This component renders the routes for the app.

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -12,15 +12,18 @@ import SiteMap from '../SiteMap'
 import Home from '../Home'
 import { useSelector } from 'react-redux'
 
+const isMemberOfOne = (user, ...groupNames) =>
+      !!user?.roles?.some((role) => groupNames.includes(role.name))
+
 /**
  * This component renders the routes for the app.
  * Routes have the 'exact' prop, so the order of routes
  * does not matter.
  */
-const AppRoutes = () => {
-  const user = useSelector((state) => state.auth.user)
+const AppRoutes = ({ user }) => {
   const role = user?.roles
   const hasRole = Boolean(role?.length > 0)
+
   const userAccessRequestApproved = Boolean(user?.['access_request'])
 
   const homeTitle =
@@ -56,7 +59,7 @@ const AppRoutes = () => {
         path="/site-map"
         element={
           <PrivateRoute title="Site Map">
-            <SiteMap />
+            <SiteMap user={user}/>
           </PrivateRoute>
         }
       />

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -13,7 +13,7 @@ import Home from '../Home'
 import { useSelector } from 'react-redux'
 
 const isMemberOfOne = (user, ...groupNames) =>
-      !!user?.roles?.some((role) => groupNames.includes(role.name))
+  !!user?.roles?.some((role) => groupNames.includes(role.name))
 
 /**
  * This component renders the routes for the app.
@@ -59,7 +59,7 @@ const AppRoutes = ({ user }) => {
         path="/site-map"
         element={
           <PrivateRoute title="Site Map">
-            <SiteMap user={user}/>
+            <SiteMap user={user} />
           </PrivateRoute>
         }
       />

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,8 +1,5 @@
 import React from 'react'
 import canViewAdmin from '../../utils/canViewAdmin'
-// I copied these from Header.jsx and slightly refactored them to accept a user as their first arguement
-// I am wanting to shift these, and similar reused pieces of code at the top of component functions
-// up the tree to be passed in from the router.
 
 const SiteMap = ({ user }) => (
   <div className="margin-top-5">

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,6 +1,17 @@
 import React, { useRef, useState } from 'react'
+import { useSelector } from 'react-redux'
 
-const SiteMap = () => (
+
+const isMemberOfOne = (user, ...groupNames) =>
+      !!user?.roles?.some((role) => groupNames.includes(role.name))
+
+const userAccessRequestApproved = (user) => !!(!user?.['access_request']) && user.roles.length > 0
+
+const canViewAdmin = (user) =>
+      userAccessRequestApproved(user) &&
+      isMemberOfOne(user,'Developer', 'OFA System Admin', 'ACF OCIO')
+
+const SiteMap = ({ user }) => (
   <div className="margin-top-5">
     <SiteMap.Link text="Home" link="/home" />
     <SiteMap.Link
@@ -9,10 +20,13 @@ const SiteMap = () => (
     />
     <SiteMap.Link text="Data Files" link="/data-files" />
     <SiteMap.Link text="Profile" link="/profile" />
-    <SiteMap.Link
-      text="Admin"
-      link={`${process.env.REACT_APP_BACKEND_HOST}/admin/`}
-    />
+
+    {canViewAdmin(user) && (
+      <SiteMap.Link
+        text="Admin"
+        link={`${process.env.REACT_APP_BACKEND_HOST}/admin/`}
+      />
+    )}
   </div>
 )
 

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,5 +1,4 @@
-import React, { useRef, useState } from 'react'
-import { useSelector } from 'react-redux'
+import React from 'react'
 
 // I copied these from Header.jsx and slightly refactored them to accept a user as their first arguement
 // I am wanting to shift these, and similar reused pieces of code at the top of component functions
@@ -14,11 +13,10 @@ const canViewAdmin = (user) =>
   userAccessRequestApproved(user) &&
   isMemberOfOne(user, 'Developer', 'OFA System Admin', 'ACF OCIO')
 
-
-const hasPermission = (permissionName) =>
-      user?.roles?.[0]?.permissions?.some(
-        (perm) => perm.codename === permissionName
-      )
+// const hasPermission = (permissionName) =>
+//   user?.roles?.[0]?.permissions?.some(
+//     (perm) => perm.codename === permissionName
+//   )
 
 const SiteMap = ({ user }) => (
   <div className="margin-top-5">

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,17 +1,8 @@
 import React from 'react'
-
+import canViewAdmin from '../../utils/canViewAdmin'
 // I copied these from Header.jsx and slightly refactored them to accept a user as their first arguement
 // I am wanting to shift these, and similar reused pieces of code at the top of component functions
 // up the tree to be passed in from the router.
-const isMemberOfOne = (user, ...groupNames) =>
-  !!user?.roles?.some((role) => groupNames.includes(role.name))
-
-const userAccessRequestApproved = (user) =>
-  user?.['access_request'] && user?.roles?.length > 0
-
-const canViewAdmin = (user) =>
-  userAccessRequestApproved(user) &&
-  isMemberOfOne(user, 'Developer', 'OFA System Admin', 'ACF OCIO')
 
 const SiteMap = ({ user }) => (
   <div className="margin-top-5">

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -7,16 +7,11 @@ const isMemberOfOne = (user, ...groupNames) =>
   !!user?.roles?.some((role) => groupNames.includes(role.name))
 
 const userAccessRequestApproved = (user) =>
-  !user?.['access_request'] && user?.roles?.length > 0
+  user?.['access_request'] && user?.roles?.length > 0
 
 const canViewAdmin = (user) =>
   userAccessRequestApproved(user) &&
   isMemberOfOne(user, 'Developer', 'OFA System Admin', 'ACF OCIO')
-
-// const hasPermission = (permissionName) =>
-//   user?.roles?.[0]?.permissions?.some(
-//     (perm) => perm.codename === permissionName
-//   )
 
 const SiteMap = ({ user }) => (
   <div className="margin-top-5">

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,0 +1,30 @@
+import React, { useRef, useState } from 'react'
+
+const SiteMap = () => (
+  <div className="margin-top-5">
+    <SiteMap.Link text="Home" link="/home" />
+    <SiteMap.Link
+      text="Privacy Policy"
+      link="https://www.acf.hhs.gov/privacy-policy"
+    />
+    <SiteMap.Link text="Data Files" link="/data-files" />
+    <SiteMap.Link text="Profile" link="/profile" />
+    <SiteMap.Link
+      text="Home"
+      link={`${process.env.REACT_APP_BACKEND_HOST}/admin/`}
+    />
+  </div>
+)
+
+SiteMap.Link = ({ text, link }) => (
+  <a
+    className="usa-footer__primary-link"
+    href={link}
+    target="_blank"
+    rel="noreferrer"
+  >
+    {text}
+  </a>
+)
+
+export default SiteMap

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -7,8 +7,11 @@ const SiteMap = ({ user }) => (
     <SiteMap.Link
       text="Privacy Policy"
       link="https://www.acf.hhs.gov/privacy-policy"
+      target="_blank"
     />
-    <SiteMap.Link text="Data Files" link="/data-files" />
+    {user?.['access_request'] && (
+      <SiteMap.Link text="Data Files" link="/data-files" />
+    )}
     <SiteMap.Link text="Profile" link="/profile" />
 
     {canViewAdmin(user) && (
@@ -20,11 +23,11 @@ const SiteMap = ({ user }) => (
   </div>
 )
 
-SiteMap.Link = ({ text, link }) => (
+SiteMap.Link = ({ text, link, target = '_self' }) => (
   <a
     className="usa-footer__primary-link"
     href={link}
-    target="_blank"
+    target={target}
     rel="noopener noreferrer"
   >
     {text}

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import canViewAdmin from '../../utils/canViewAdmin'
+import {
+  canViewAdmin,
+  userAccessRequestApproved,
+} from '../../utils/canViewAdmin'
 
 const SiteMap = ({ user }) => (
   <div className="margin-top-5">
@@ -9,7 +12,7 @@ const SiteMap = ({ user }) => (
       link="https://www.acf.hhs.gov/privacy-policy"
       target="_blank"
     />
-    {user?.['access_request'] && (
+    {userAccessRequestApproved(user) && (
       <SiteMap.Link text="Data Files" link="/data-files" />
     )}
     <SiteMap.Link text="Profile" link="/profile" />

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -10,7 +10,7 @@ const SiteMap = () => (
     <SiteMap.Link text="Data Files" link="/data-files" />
     <SiteMap.Link text="Profile" link="/profile" />
     <SiteMap.Link
-      text="Home"
+      text="Admin"
       link={`${process.env.REACT_APP_BACKEND_HOST}/admin/`}
     />
   </div>

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -1,15 +1,24 @@
 import React, { useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 
-
+// I copied these from Header.jsx and slightly refactored them to accept a user as their first arguement
+// I am wanting to shift these, and similar reused pieces of code at the top of component functions
+// up the tree to be passed in from the router.
 const isMemberOfOne = (user, ...groupNames) =>
-      !!user?.roles?.some((role) => groupNames.includes(role.name))
+  !!user?.roles?.some((role) => groupNames.includes(role.name))
 
-const userAccessRequestApproved = (user) => !!(!user?.['access_request']) && user.roles.length > 0
+const userAccessRequestApproved = (user) =>
+  !user?.['access_request'] && user?.roles?.length > 0
 
 const canViewAdmin = (user) =>
-      userAccessRequestApproved(user) &&
-      isMemberOfOne(user,'Developer', 'OFA System Admin', 'ACF OCIO')
+  userAccessRequestApproved(user) &&
+  isMemberOfOne(user, 'Developer', 'OFA System Admin', 'ACF OCIO')
+
+
+const hasPermission = (permissionName) =>
+      user?.roles?.[0]?.permissions?.some(
+        (perm) => perm.codename === permissionName
+      )
 
 const SiteMap = ({ user }) => (
   <div className="margin-top-5">

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.jsx
@@ -21,7 +21,7 @@ SiteMap.Link = ({ text, link }) => (
     className="usa-footer__primary-link"
     href={link}
     target="_blank"
-    rel="noreferrer"
+    rel="noopener noreferrer"
   >
     {text}
   </a>

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import thunk from 'redux-thunk'
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import configureStore from 'redux-mock-store'
 import SiteMap from './SiteMap'
 import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
 
 describe('SiteMap', () => {
   const initialState = {
@@ -19,49 +20,64 @@ describe('SiteMap', () => {
   }
 
   it('When an authenticated Developer visits the sitemap', () => {
-    const mockStore = configureStore([thunk])
-    const store = mockStore({
-      ...initialState,
-      auth: {
-        authenticated: true,
-        user: {
-          email: 'hi@bye.com',
-          roles: [{ id: 1, name: 'Developer', permission: [] }],
-          access_request: true,
-        },
-      },
-    })
-
-    const { getByText } = render(
-      <Provider store={store}>
-        <SiteMap />
-      </Provider>
-    )
-
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
-    for (let location of locations) {
-      expect(getByText(location)).toBeInTheDocument()
-    }
-  })
-
-  it('When an authenticated Admin visits the sitemap', () => {
     const user = {
       email: 'hi@bye.com',
-      roles: [{ id: 1, name: 'OFA System Admin', permission: [] }],
+      roles: [{ id: 1, name: 'Developer', permissions: [] }],
       access_request: true,
     }
 
     const { getByText } = render(<SiteMap user={user}></SiteMap>)
 
-    const locations = [
-      'Home',
-      'Privacy Policy',
-      'Data Files',
-      'Profile',
-      'Admin',
-    ]
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }
   })
+
+  it('When an authenticated OFA System Admin visits the sitemap', () => {
+    const user = {
+      email: 'hi@bye.com',
+      roles: [{ id: 1, name: 'OFA System Admin', permissions: [] }],
+      access_request: true,
+    }
+
+    const { getByText } = render(<SiteMap user={user}></SiteMap>)
+
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+    for (let location of locations) {
+      expect(getByText(location)).toBeInTheDocument()
+    }
+  }) 
+
+  it('When an authenticated ACF OCIO visits the sitemap', () => {
+    const user = {
+      email: 'hi@bye.com',
+      roles: [{ id: 1, name: 'ACF OCIO', permissions: [] }],
+      access_request: true,
+    }
+
+    const { getByText } = render(<SiteMap user={user}></SiteMap>)
+
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+    for (let location of locations) {
+      expect(getByText(location)).toBeInTheDocument()
+    }
+  })
+  it('When an authenticated Data Analyst visits the sitemap', () => {
+    const user = {
+      email: 'hi@bye.com',
+      roles: [{ id: 1, name: 'Data Analyst', permissions: [] }],
+      access_request: true,
+    }
+
+    const { getByText } = render(<SiteMap user={user}></SiteMap>)
+
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
+    for (let location of locations) {
+      expect(getByText(location)).toBeInTheDocument()
+    }
+    const wrapper = mount(<SiteMap user={user}></SiteMap>)
+    expect(wrapper.html()).not.toContain('Admin')
+    expect(wrapper.html()).toContain('Home')
+  }) 
 })

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -45,24 +45,13 @@ describe('SiteMap', () => {
   })
 
   it('When an authenticated Admin visits the sitemap', () => {
-    const mockStore = configureStore([thunk])
-    const store = mockStore({
-      ...initialState,
-      auth: {
-        authenticated: true,
-        user: {
-          email: 'hi@bye.com',
-          roles: [{ id: 1, name: 'OFA System Admin', permission: [] }],
-          access_request: true,
-        },
-      },
-    })
+    const user = {
+      email: 'hi@bye.com',
+      roles: [{ id: 1, name: 'OFA System Admin', permission: [] }],
+      access_request: true,
+    }
 
-    const { getByText } = render(
-      <Provider store={store}>
-        <SiteMap />
-      </Provider>
-    )
+    const { getByText } = render(<SiteMap user={user}></SiteMap>)
 
     const locations = [
       'Home',

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -6,7 +6,6 @@ import SiteMap from './SiteMap'
 import { Provider } from 'react-redux'
 
 describe('SiteMap', () => {
-
   const initialState = {
     router: { location: { pathname: '/home' } },
     auth: {
@@ -65,7 +64,13 @@ describe('SiteMap', () => {
       </Provider>
     )
 
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+    const locations = [
+      'Home',
+      'Privacy Policy',
+      'Data Files',
+      'Profile',
+      'Admin',
+    ]
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -1,0 +1,22 @@
+
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import SiteMap from './SiteMap'
+
+describe('SiteMap', () => {
+
+  const locations = [
+    "Home",
+    "Privacy Policy",
+    "Data Files",
+    "Profile",
+    "Admin",
+  ]
+  for(let location of locations) {
+    it(`renders the $(location) link`, () => {
+      const { getByText } = render(<SiteMap />)
+      expect(getByText(location)).toBeInTheDocument()
+    })
+  }
+})

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -1,53 +1,131 @@
 import React from 'react'
-import { render } from '@testing-library/react'
-
+import thunk from 'redux-thunk'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import configureStore from 'redux-mock-store'
+import SplashPage from '../SplashPage'
 import SiteMap from './SiteMap'
+import { permissions } from '../Header/developer_permissions'
+import PrivateRoute from '../PrivateRoute'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
 describe('SiteMap', () => {
-
-  describe("When an non-admin user visits the sitemap",() =>{
-
+  it('When a non authenticated user visits the splash page do not show sitemap', () => {
     const initialState = {
       auth: { authenticated: false, inactive: false },
-      roles:[]
+      roles: [],
     }
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
-    for (let location of locations) {
-      it(`renders the $(location) link`, () => {
-        const { getByText } = render(<SiteMap />)
-        expect(getByText(location)).toBeInTheDocument()
-      })
-    }
+    const mockStore = configureStore([thunk])
 
+    const store = mockStore(initialState)
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <SplashPage />
+      </Provider>
+    )
+
+    const footer = wrapper.find('footer')
+    expect(footer).not.toIncludeText('Site Map')
   })
-  describe("When an admin user visits the sitemap",() => {
 
+  it('When an authenticated developer visits the splash page show sitemap', () => {
+    const initialState = {
+      router: { location: { pathname: '/home' } },
+      auth: {
+        user: {
+          email: 'test@test.com',
+          roles: [{ id: 1, name: 'Developer', permissions }],
+          access_request: true,
+        },
+        authenticated: true,
+      },
+    }
+
+    const mockStore = configureStore([thunk])
+    const store = mockStore(initialState)
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <SplashPage />
+      </Provider>
+    )
+
+    const footer = wrapper.find('footer')
+    expect(footer.find('.usa-footer')).toIncludeText('Site Map')
+  })
+
+  it('When an authenticated admin visits the splash page show sitemap', () => {
+    const initialState = {
+      router: { location: { pathname: '/home' } },
+      auth: {
+        user: {
+          email: 'test@test.com',
+          roles: [{ id: 1, name: 'Admin', permissions }],
+          access_request: true,
+        },
+        authenticated: true,
+      },
+    }
+
+    const mockStore = configureStore([thunk])
+    const store = mockStore(initialState)
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/home', '/']}>
+          <Routes>
+            <Route
+              exact
+              path="/home"
+              element={
+                <PrivateRoute title="Welcome to TDP">
+                  <SplashPage />
+                </PrivateRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    )
+
+    const footer = wrapper.find('footer')
+    expect(footer.find('.usa-footer')).not.toIncludeText('Site Map')
+  })
+
+  it('When an non-authenticated user visits the sitemap', () => {
     const initialState = {
       auth: { authenticated: false, inactive: false },
-      roles:[{name:"Developer"}]
+      roles: [],
     }
+    const mockStore = configureStore([thunk])
+    const store = mockStore(initialState)
+    const wrapper = mount(
+      <Provider store={store}>
+        <SplashPage />
+      </Provider>
+    )
+
     const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
+    const footer = wrapper.find('footer')
     for (let location of locations) {
-      it(`renders the $(location) link`, () => {
-        const { getByText } = render(<SiteMap />)
-        expect(getByText(location)).toBeInTheDocument()
-      })
+      expect(getByText(location)).toBeInTheDocument()
     }
   })
 
-  describe("When an unapproved user visits the sitemap",() => {
-
+  it('When an authenticated user visits the sitemap', () => {
     const initialState = {
       auth: { authenticated: false, inactive: false },
-      roles:[{name:"Developer"}]
+      roles: [],
     }
+    const mockStore = configureStore([thunk])
+    const store = mockStore(initialState)
+    const { getByText } = render(<SiteMap store={store} />)
+
     const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
     for (let location of locations) {
-      it(`renders the $(location) link`, () => {
-        const { getByText } = render(<SiteMap />)
-        expect(getByText(location)).toBeInTheDocument()
-      })
+      expect(getByText(location)).toBeInTheDocument()
     }
   })
-
 })

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -1,19 +1,11 @@
-
 import React from 'react'
 import { render } from '@testing-library/react'
 
 import SiteMap from './SiteMap'
 
 describe('SiteMap', () => {
-
-  const locations = [
-    "Home",
-    "Privacy Policy",
-    "Data Files",
-    "Profile",
-    "Admin",
-  ]
-  for(let location of locations) {
+  const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+  for (let location of locations) {
     it(`renders the $(location) link`, () => {
       const { getByText } = render(<SiteMap />)
       expect(getByText(location)).toBeInTheDocument()

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -5,14 +5,49 @@ import SiteMap from './SiteMap'
 
 describe('SiteMap', () => {
 
-  const initialState = {
-    auth: { authenticated: false, inactive: false },
-  }
-  const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
-  for (let location of locations) {
-    it(`renders the $(location) link`, () => {
-      const { getByText } = render(<SiteMap />)
-      expect(getByText(location)).toBeInTheDocument()
-    })
-  }
+  describe("When an non-admin user visits the sitemap",() =>{
+
+    const initialState = {
+      auth: { authenticated: false, inactive: false },
+      roles:[]
+    }
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
+    for (let location of locations) {
+      it(`renders the $(location) link`, () => {
+        const { getByText } = render(<SiteMap />)
+        expect(getByText(location)).toBeInTheDocument()
+      })
+    }
+
+  })
+  describe("When an admin user visits the sitemap",() => {
+
+    const initialState = {
+      auth: { authenticated: false, inactive: false },
+      roles:[{name:"Developer"}]
+    }
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
+    for (let location of locations) {
+      it(`renders the $(location) link`, () => {
+        const { getByText } = render(<SiteMap />)
+        expect(getByText(location)).toBeInTheDocument()
+      })
+    }
+  })
+
+  describe("When an unapproved user visits the sitemap",() => {
+
+    const initialState = {
+      auth: { authenticated: false, inactive: false },
+      roles:[{name:"Developer"}]
+    }
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
+    for (let location of locations) {
+      it(`renders the $(location) link`, () => {
+        const { getByText } = render(<SiteMap />)
+        expect(getByText(location)).toBeInTheDocument()
+      })
+    }
+  })
+
 })

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -1,129 +1,71 @@
 import React from 'react'
 import thunk from 'redux-thunk'
-import { Provider } from 'react-redux'
-import { mount } from 'enzyme'
 import { render, screen } from '@testing-library/react'
 import configureStore from 'redux-mock-store'
-import SplashPage from '../SplashPage'
 import SiteMap from './SiteMap'
-import { permissions } from '../Header/developer_permissions'
-import PrivateRoute from '../PrivateRoute'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { Provider } from 'react-redux'
 
 describe('SiteMap', () => {
-  it('When a non authenticated user visits the splash page do not show sitemap', () => {
-    const initialState = {
-      auth: { authenticated: false, inactive: false },
-      roles: [],
-    }
+
+  const initialState = {
+    router: { location: { pathname: '/home' } },
+    auth: {
+      user: {
+        email: 'test@test.com',
+        roles: [{ id: 1, name: 'Developer', permissions: [] }],
+        access_request: true,
+      },
+      authenticated: true,
+    },
+  }
+
+  it('When an authenticated Developer visits the sitemap', () => {
     const mockStore = configureStore([thunk])
-
-    const store = mockStore(initialState)
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <SplashPage />
-      </Provider>
-    )
-
-    const footer = wrapper.find('footer')
-    expect(footer).not.toIncludeText('Site Map')
-  })
-
-  it('When an authenticated developer visits the splash page show sitemap', () => {
-    const initialState = {
-      router: { location: { pathname: '/home' } },
+    const store = mockStore({
+      ...initialState,
       auth: {
+        authenticated: true,
         user: {
-          email: 'test@test.com',
-          roles: [{ id: 1, name: 'Developer', permissions }],
+          email: 'hi@bye.com',
+          roles: [{ id: 1, name: 'Developer', permission: [] }],
           access_request: true,
         },
-        authenticated: true,
       },
-    }
+    })
 
-    const mockStore = configureStore([thunk])
-    const store = mockStore(initialState)
-
-    const wrapper = mount(
+    const { getByText } = render(
       <Provider store={store}>
-        <SplashPage />
-      </Provider>
-    )
-
-    const footer = wrapper.find('footer')
-    expect(footer.find('.usa-footer')).toIncludeText('Site Map')
-  })
-
-  it('When an authenticated admin visits the splash page show sitemap', () => {
-    const initialState = {
-      router: { location: { pathname: '/home' } },
-      auth: {
-        user: {
-          email: 'test@test.com',
-          roles: [{ id: 1, name: 'Admin', permissions }],
-          access_request: true,
-        },
-        authenticated: true,
-      },
-    }
-
-    const mockStore = configureStore([thunk])
-    const store = mockStore(initialState)
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={['/home', '/']}>
-          <Routes>
-            <Route
-              exact
-              path="/home"
-              element={
-                <PrivateRoute title="Welcome to TDP">
-                  <SplashPage />
-                </PrivateRoute>
-              }
-            />
-          </Routes>
-        </MemoryRouter>
-      </Provider>
-    )
-
-    const footer = wrapper.find('footer')
-    expect(footer.find('.usa-footer')).not.toIncludeText('Site Map')
-  })
-
-  it('When an non-authenticated user visits the sitemap', () => {
-    const initialState = {
-      auth: { authenticated: false, inactive: false },
-      roles: [],
-    }
-    const mockStore = configureStore([thunk])
-    const store = mockStore(initialState)
-    const wrapper = mount(
-      <Provider store={store}>
-        <SplashPage />
+        <SiteMap />
       </Provider>
     )
 
     const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
-    const footer = wrapper.find('footer')
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }
   })
 
-  it('When an authenticated user visits the sitemap', () => {
-    const initialState = {
-      auth: { authenticated: false, inactive: false },
-      roles: [],
-    }
+  it('When an authenticated Admin visits the sitemap', () => {
     const mockStore = configureStore([thunk])
-    const store = mockStore(initialState)
-    const { getByText } = render(<SiteMap store={store} />)
+    const store = mockStore({
+      ...initialState,
+      auth: {
+        authenticated: true,
+        user: {
+          email: 'hi@bye.com',
+          roles: [{ id: 1, name: 'OFA System Admin', permission: [] }],
+          access_request: true,
+        },
+      },
+    })
 
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile']
+    const { getByText } = render(
+      <Provider store={store}>
+        <SiteMap />
+      </Provider>
+    )
+
+    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -4,6 +4,10 @@ import { render } from '@testing-library/react'
 import SiteMap from './SiteMap'
 
 describe('SiteMap', () => {
+
+  const initialState = {
+    auth: { authenticated: false, inactive: false },
+  }
   const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
   for (let location of locations) {
     it(`renders the $(location) link`, () => {

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -95,4 +95,22 @@ describe('SiteMap', () => {
     expect(wrapper.html()).not.toContain('Admin')
     expect(wrapper.html()).toContain('Home')
   })
+
+  it('When an authenticated user that does not yet have access visits the sitemap', () => {
+    const user = {
+      email: 'hi@bye.com',
+      roles: [],
+      access_request: false,
+    }
+
+    const { getByText } = render(<SiteMap user={user}></SiteMap>)
+
+    const locations = ['Home', 'Privacy Policy', 'Profile']
+    for (let location of locations) {
+      expect(getByText(location)).toBeInTheDocument()
+    }
+    const wrapper = mount(<SiteMap user={user}></SiteMap>)
+    expect(wrapper.html()).not.toContain('Admin')
+    expect(wrapper.html()).toContain('Home')
+  })
 })

--- a/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
+++ b/tdrs-frontend/src/components/SiteMap/SiteMap.test.js
@@ -1,9 +1,6 @@
 import React from 'react'
-import thunk from 'redux-thunk'
 import { render } from '@testing-library/react'
-import configureStore from 'redux-mock-store'
 import SiteMap from './SiteMap'
-import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 
 describe('SiteMap', () => {
@@ -28,7 +25,13 @@ describe('SiteMap', () => {
 
     const { getByText } = render(<SiteMap user={user}></SiteMap>)
 
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+    const locations = [
+      'Home',
+      'Privacy Policy',
+      'Data Files',
+      'Profile',
+      'Admin',
+    ]
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }
@@ -43,11 +46,17 @@ describe('SiteMap', () => {
 
     const { getByText } = render(<SiteMap user={user}></SiteMap>)
 
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+    const locations = [
+      'Home',
+      'Privacy Policy',
+      'Data Files',
+      'Profile',
+      'Admin',
+    ]
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }
-  }) 
+  })
 
   it('When an authenticated ACF OCIO visits the sitemap', () => {
     const user = {
@@ -58,7 +67,13 @@ describe('SiteMap', () => {
 
     const { getByText } = render(<SiteMap user={user}></SiteMap>)
 
-    const locations = ['Home', 'Privacy Policy', 'Data Files', 'Profile', 'Admin']
+    const locations = [
+      'Home',
+      'Privacy Policy',
+      'Data Files',
+      'Profile',
+      'Admin',
+    ]
     for (let location of locations) {
       expect(getByText(location)).toBeInTheDocument()
     }
@@ -79,5 +94,5 @@ describe('SiteMap', () => {
     const wrapper = mount(<SiteMap user={user}></SiteMap>)
     expect(wrapper.html()).not.toContain('Admin')
     expect(wrapper.html()).toContain('Home')
-  }) 
+  })
 })

--- a/tdrs-frontend/src/components/SiteMap/index.js
+++ b/tdrs-frontend/src/components/SiteMap/index.js
@@ -1,0 +1,3 @@
+import SiteMap from './SiteMap'
+
+export default SiteMap

--- a/tdrs-frontend/src/utils/canViewAdmin.js
+++ b/tdrs-frontend/src/utils/canViewAdmin.js
@@ -1,10 +1,10 @@
 const isMemberOfOne = (user, groupNames) =>
   user?.roles?.some((role) => groupNames.includes(role.name))
 
-const userAccessRequestApproved = (user) =>
+export const userAccessRequestApproved = (user) =>
   user?.['access_request'] && user?.roles?.length > 0
 
-const canViewAdmin = (user) =>
+export const canViewAdmin = (user) =>
   userAccessRequestApproved(user) &&
   isMemberOfOne(user, [
     'Developer',
@@ -12,5 +12,3 @@ const canViewAdmin = (user) =>
     'ACF OCIO',
     'OFA Admin',
   ])
-
-export default canViewAdmin

--- a/tdrs-frontend/src/utils/canViewAdmin.js
+++ b/tdrs-frontend/src/utils/canViewAdmin.js
@@ -1,4 +1,4 @@
-const isMemberOfOne = (user, ...groupNames) =>
+const isMemberOfOne = (user, groupNames) =>
   !!user?.roles?.some((role) => groupNames.includes(role.name))
 
 const userAccessRequestApproved = (user) =>
@@ -6,6 +6,6 @@ const userAccessRequestApproved = (user) =>
 
 const canViewAdmin = (user) =>
   userAccessRequestApproved(user) &&
-  isMemberOfOne(user, 'Developer', 'OFA System Admin', 'ACF OCIO')
+  isMemberOfOne(user, ['Developer', 'OFA System Admin', 'ACF OCIO'])
 
 export default canViewAdmin

--- a/tdrs-frontend/src/utils/canViewAdmin.js
+++ b/tdrs-frontend/src/utils/canViewAdmin.js
@@ -6,6 +6,11 @@ const userAccessRequestApproved = (user) =>
 
 const canViewAdmin = (user) =>
   userAccessRequestApproved(user) &&
-  isMemberOfOne(user, ['Developer', 'OFA System Admin', 'ACF OCIO'])
+  isMemberOfOne(user, [
+    'Developer',
+    'OFA System Admin',
+    'ACF OCIO',
+    'OFA Admin',
+  ])
 
 export default canViewAdmin

--- a/tdrs-frontend/src/utils/canViewAdmin.js
+++ b/tdrs-frontend/src/utils/canViewAdmin.js
@@ -1,0 +1,11 @@
+const isMemberOfOne = (user, ...groupNames) =>
+  !!user?.roles?.some((role) => groupNames.includes(role.name))
+
+const userAccessRequestApproved = (user) =>
+  user?.['access_request'] && user?.roles?.length > 0
+
+const canViewAdmin = (user) =>
+  userAccessRequestApproved(user) &&
+  isMemberOfOne(user, 'Developer', 'OFA System Admin', 'ACF OCIO')
+
+export default canViewAdmin

--- a/tdrs-frontend/src/utils/canViewAdmin.js
+++ b/tdrs-frontend/src/utils/canViewAdmin.js
@@ -1,5 +1,5 @@
 const isMemberOfOne = (user, groupNames) =>
-  !!user?.roles?.some((role) => groupNames.includes(role.name))
+  user?.roles?.some((role) => groupNames.includes(role.name))
 
 const userAccessRequestApproved = (user) =>
   user?.['access_request'] && user?.roles?.length > 0


### PR DESCRIPTION
## Summary of Changes
_Provide a brief summary of changes_
Pull request closes #1787 

## How to Test
_List the steps to test the PR_
These steps are generic, please adjust as necessary.
```
cd tdrs-frontend && docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d
cd tdrs-backend && docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d 
```

1. Open http://localhost:3000/, on the spash page there will be no sitemap
2. Sign in and the sitemap link will appear at the bottom.
3. Go to site map and test the links.
4. Accounts with admin access will see the admin page link in the site map.
5. Accounts without admin access will not.

![Screen Shot 2022-08-11 at 9 55 10 AM](https://user-images.githubusercontent.com/7119690/184191119-dc2d32fa-2497-4465-b63c-6c1962fea3a3.png)
![Screen Shot 2022-08-11 at 9 55 17 AM](https://user-images.githubusercontent.com/7119690/184191152-b35d745e-23f0-4a1f-ae06-53b53f275aee.png)
![Screen Shot 2022-08-11 at 9 55 29 AM](https://user-images.githubusercontent.com/7119690/184191166-a3c605e4-c43e-4248-9772-b05f0a0e4d3f.png)

