### PR TITLE
Feat/2090 transferred files must renamed acf titan

### DIFF
--- a/tdrs-backend/tdpservice/data_files/models.py
+++ b/tdrs-backend/tdpservice/data_files/models.py
@@ -150,8 +150,8 @@ class DataFile(FileRecord):
     def filename(self):
         """Return the correct filename for this data file."""
         # TODO: This is interim logic, it has to be changed when all sections are available to requester
-        if self.stt.type == 'tribe':
-            return self.stt.filenames.get('Tribal ' if 'Tribal' not in self.section else '' + self.section,
+        if str(self.stt.type).lower() == 'tribe':
+            return self.stt.filenames.get(('Tribal ' if 'Tribal' not in self.section else '') + self.section,
                                           self.create_filename())
         else:
             return self.stt.filenames.get(self.section, self.create_filename())

--- a/tdrs-backend/tdpservice/data_files/models.py
+++ b/tdrs-backend/tdpservice/data_files/models.py
@@ -149,10 +149,13 @@ class DataFile(FileRecord):
     @property
     def filename(self):
         """Return the correct filename for this data file."""
-        return self.stt.filenames.get(self.section, self.create_filename())
+        return self.stt.filenames.get(
+            self.section if self.stt.type == 'state' else 'Tribal ' + self.section,
+            self.create_filename())
 
     def create_filename(self, prefix='ADS.E2J'):
         """Return a valid file name for sftp transfer."""
+        """TODO: This method has to be changed when the """
         # STT_TYPES = ["state", "territory", "tribe"]
         SECTION = [i.value for i in list(self.Section)]
 

--- a/tdrs-backend/tdpservice/data_files/models.py
+++ b/tdrs-backend/tdpservice/data_files/models.py
@@ -149,9 +149,12 @@ class DataFile(FileRecord):
     @property
     def filename(self):
         """Return the correct filename for this data file."""
-        return self.stt.filenames.get(
-            self.section if self.stt.type == 'state' else 'Tribal ' + self.section,
-            self.create_filename())
+        # TODO: This is interim logic, it has to be changed when all sections are available to requester
+        if self.stt.type == 'tribe':
+            return self.stt.filenames.get('Tribal ' if 'Tribal' not in self.section else '' + self.section,
+                                          self.create_filename())
+        else:
+            return self.stt.filenames.get(self.section, self.create_filename())
 
     def create_filename(self, prefix='ADS.E2J'):
         """Return a valid file name for sftp transfer."""

--- a/tdrs-backend/tdpservice/data_files/test/test_models.py
+++ b/tdrs-backend/tdpservice/data_files/test/test_models.py
@@ -81,4 +81,7 @@ def test_data_files_filename_is_expected(user):
                 "user": user,
                 "stt": stt
             })
-            assert new_data_file.filename == stt.filenames[section]
+            if stt.type == 'tribe':
+                assert new_data_file.filename == stt.filenames['Tribal ' if 'Tribal' not in section else '' + section]
+            else:
+                assert new_data_file.filename == stt.filenames[section]


### PR DESCRIPTION
## Summary of Changes
_Provide a brief summary of changes_
Pull request closes #2090 _

## How to Test
_List the steps to test the PR_
These steps are generic, please adjust as necessary.
```
cd tdrs-frontend && docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d
cd tdrs-backend && docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d 
```

1. Open http://localhost:3000/ and sign in.
1. Proceed with functional tests as described herein.
1. Test steps should be captured in the demo GIF(s) and/or screenshots below.
> *Demo GIF(s) and screenshots for testing procedure*

## Deliverables
_More details on how deliverables herein are assessed included [here](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [ ] The uploaded filenames should be correct based on section for Tribes and States
+ [ ] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [ ] If this PR introduces backend code changes, are they meaningfully tested?
  + [ ] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [ ] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [ ] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [x] Are backend code style checks passing on CircleCI?
+ [x] Are frontend code style checks passing on CircleCI?
+ [x] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic? 
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review? 
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?


### [Deliverable 5: Deployed](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [ ] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [ ] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [ ] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [ ] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 

### [Deliverable 8: User Research](../docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

Research product(s) clearly articulate(s):
+ [ ] the purpose of the research
+ [ ] methods used to conduct the research 
+ [ ] who participated in the research
+ [ ] what was tested and how
+ [ ] impact of research on TDP
+ [ ] (_if applicable_) final design mockups produced for TDP development 


