### PR TITLE
Move redis uri to manifest and docker

### DIFF
--- a/tdrs-backend/Dockerfile
+++ b/tdrs-backend/Dockerfile
@@ -7,6 +7,7 @@ ARG uid=1000
 ARG gid=1000
 ENV DJANGO_SETTINGS_MODULE=tdpservice.settings.local
 ENV DJANGO_CONFIGURATION=Local
+ENV REDIS_URI="redis://redis-server:6379"
 # Allows docker to cache installed dependencies between builds
 COPY Pipfile Pipfile.lock /tdpapp/
 WORKDIR /tdpapp/

--- a/tdrs-backend/gunicorn_start.sh
+++ b/tdrs-backend/gunicorn_start.sh
@@ -6,11 +6,9 @@ echo "REDIS_SERVER"
 echo "redis local: $REDIS_SERVER_LOCAL"
 if [[ "$REDIS_SERVER_LOCAL" = "TRUE" || "$CIRCLE_JOB" = "backend-owasp-scan" ]]; then
     echo "Run redis server on docker"
-    export REDIS_URI="redis://redis-server:6379"
 else
     echo "Run redis server locally"
     export LD_LIBRARY_PATH=/home/vcap/deps/0/lib/:/home/vcap/deps/1/lib:$LD_LIBRARY_PATH
-    export REDIS_URI="redis://localhost:6379"
     ( cd  /home/vcap/deps/0/bin/; ./redis-server /home/vcap/app/redis.conf &)
 fi
 

--- a/tdrs-backend/manifest.buildpack.yml
+++ b/tdrs-backend/manifest.buildpack.yml
@@ -4,6 +4,8 @@ applications:
   memory: 512M
   instances: 1
   disk_quota: 2G
+  env:
+    REDIS_URI: redis://localhost:6379
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack
   - https://github.com/cloudfoundry/python-buildpack.git#v1.7.53


### PR DESCRIPTION
This is a proposition for minimizing if logic in bottom level deployment scripts. 

If `gunicorn_start.sh` has logic that checks the context of the pipeline then it will be dependent on the steps that came before; it will be tightly coupled. Bottom level scripts should be loosely coupled by taking their context from the scripts/actions that call them.

Moving forward I propose we identify the different ways our deploy scripts are called, identify the variables that are different between these starting locations, then use those starting locations as a the place to set the variables. 