### PR TITLE
Pinning version of zap2docker to 2.11.0

### DIFF
--- a/tdrs-backend/docker-compose.yml
+++ b/tdrs-backend/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.4"
 
 services:
   zaproxy:
-    image: owasp/zap2docker-stable:latest
+    image: owasp/zap2docker-stable:2.11.0
     command: sleep 3600
     depends_on:
       - web


### PR DESCRIPTION
## Summary of Changes


Latest image is broken [seen here](https://app.circleci.com/pipelines/github/raft-tech/TANF-app/11083/workflows/644b697c-a83b-4a4e-9e10-c350bec66834/jobs/28656):
```
circleci@ip-172-28-9-217:~/tdp-apps/tdrs-backend$ docker run -it owasp/zap2docker-stable /bin/bash
zap@6cd9025295b1:/zap$ sudo su -
bash: sudo: command not found
zap@6cd9025295b1:/zap$ ls
CHANGELOG.md  container  lang  license  scripts   xml             zap-api-scan.py  zap-full-scan.py  zap-x.sh  zap.ico  zap_common.py
README        db         lib   plugin   webswing  zap-2.12.0.jar  zap-baseline.py  zap-webswing.sh   zap.bat   zap.sh
zap@6cd9025295b1:/zap$ which pip
/usr/bin/pip
zap@6cd9025295b1:/zap$ pip --version
pip 22.3 from /usr/lib/python3/dist-packages/pip (python 3.10)
zap@6cd9025295b1:/zap$ pip install wait-for-it
Defaulting to user installation because normal site-packages is not writeable
Collecting wait-for-it
  Downloading wait_for_it-2.2.1-py3-none-any.whl (8.1 kB)
Collecting click
  Downloading click-8.1.3-py3-none-any.whl (96 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/96.6 kB ? eta -:--:--ERROR: Exception:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pip/_internal/cli/base_command.py", line 160, in exc_logging_wrapper
    status = run_func(*args)
  File "/usr/lib/python3/dist-packages/pip/_internal/cli/req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "/usr/lib/python3/dist-packages/pip/_internal/commands/install.py", line 400, in run
    requirement_set = resolver.resolve(
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/resolver.py", line 92, in resolve
    result = self._result = resolver.resolve(
  File "/usr/lib/python3/dist-packages/pip/_vendor/resolvelib/resolvers.py", line 481, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/usr/lib/python3/dist-packages/pip/_vendor/resolvelib/resolvers.py", line 373, in resolve
    failure_causes = self._attempt_to_pin_criterion(name)
  File "/usr/lib/python3/dist-packages/pip/_vendor/resolvelib/resolvers.py", line 213, in _attempt_to_pin_criterion
    criteria = self._get_updated_criteria(candidate)
  File "/usr/lib/python3/dist-packages/pip/_vendor/resolvelib/resolvers.py", line 204, in _get_updated_criteria
    self._add_to_criteria(criteria, requirement, parent=candidate)
  File "/usr/lib/python3/dist-packages/pip/_vendor/resolvelib/resolvers.py", line 172, in _add_to_criteria
    if not criterion.candidates:
  File "/usr/lib/python3/dist-packages/pip/_vendor/resolvelib/structs.py", line 151, in __bool__
    return bool(self._sequence)
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/found_candidates.py", line 155, in __bool__
    return any(self)
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/found_candidates.py", line 143, in <genexpr>
    return (c for c in iterator if id(c) not in self._incompatible_ids)
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/found_candidates.py", line 47, in _iter_built
    candidate = func()
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/factory.py", line 206, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/candidates.py", line 297, in __init__
    super().__init__(
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/candidates.py", line 162, in __init__
    self.dist = self._prepare()
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/candidates.py", line 231, in _prepare
    dist = self._prepare_distribution()
  File "/usr/lib/python3/dist-packages/pip/_internal/resolution/resolvelib/candidates.py", line 308, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "/usr/lib/python3/dist-packages/pip/_internal/operations/prepare.py", line 491, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "/usr/lib/python3/dist-packages/pip/_internal/operations/prepare.py", line 536, in _prepare_linked_requirement
    local_file = unpack_url(
  File "/usr/lib/python3/dist-packages/pip/_internal/operations/prepare.py", line 166, in unpack_url
    file = get_http_url(
  File "/usr/lib/python3/dist-packages/pip/_internal/operations/prepare.py", line 107, in get_http_url
    from_path, content_type = download(link, temp_dir.path)
  File "/usr/lib/python3/dist-packages/pip/_internal/network/download.py", line 147, in __call__
    for chunk in chunks:
  File "/usr/lib/python3/dist-packages/pip/_internal/cli/progress_bars.py", line 52, in _rich_progress_bar
    with progress:
  File "/usr/lib/python3/dist-packages/pip/_vendor/rich/progress.py", line 1165, in __enter__
    self.start()
  File "/usr/lib/python3/dist-packages/pip/_vendor/rich/progress.py", line 1156, in start
    self.live.start(refresh=True)
  File "/usr/lib/python3/dist-packages/pip/_vendor/rich/live.py", line 132, in start
    self._refresh_thread.start()
  File "/usr/lib/python3.10/threading.py", line 935, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't start new thread
```

After troubleshooting, found this workaround with the version change in this file.
Successful run:
```
circleci@ip-172-28-9-217:~/tdp-apps/tdrs-backend$ vim docker-compose.yml
circleci@ip-172-28-9-217:~/tdp-apps/tdrs-backend$ docker-compose run --rm zaproxy bash -c   "PATH=$PATH:/home/zap/.local/bin &&
   pip install wait-for-it &&
   wait-for-it --service http://web:8080 \
               --timeout 60 \
               -- echo \"Django is ready\""
Creating tdrs-backend_zaproxy_run ... done
Defaulting to user installation because normal site-packages is not writeable
Collecting wait-for-it
  Downloading wait_for_it-2.2.1-py3-none-any.whl (8.1 kB)
Requirement already satisfied: click in /usr/local/lib/python3.8/dist-packages (from wait-for-it) (4.0)
Installing collected packages: wait-for-it
Successfully installed wait-for-it-2.2.1
WARNING: You are using pip version 21.3.1; however, version 22.3 is available.
You should consider upgrading via the '/usr/bin/python3 -m pip install --upgrade pip' command.
[*] Waiting 60 seconds for web:8080
[+] web:8080 is available after 0 seconds
Django is ready
```