### PR TITLE
Pin zap version to 2.11.0 for frontend scan 

### DIFF
--- a/tdrs-frontend/docker-compose.yml
+++ b/tdrs-frontend/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   zaproxy:
-    image: owasp/zap2docker-stable
+    image: owasp/zap2docker-stable:2.11.0
     container_name: zap-scan
     command: sleep 3600
     ports:


### PR DESCRIPTION
## Summary of Changes
pinning zap version to 2.11.0 in preparation for next release. this should remove the frontend findings that we are seeing [here](https://output.circle-artifacts.com/output/job/a8642ce0-2225-47a6-b3b7-491296dd3163/artifacts/0/tdrs-frontend/reports/owasp_report.html)


+ [x] Does the OWASP Scan pass on CircleCI?

[frontend](https://output.circle-artifacts.com/output/job/62745f9b-d65c-489f-bf0f-99f01362adbe/artifacts/0/tdrs-frontend/reports/owasp_report.html)
[backend](https://output.circle-artifacts.com/output/job/31371c90-ddd1-4ca2-8d21-17822169ba5b/artifacts/0/tdrs-backend/reports/owasp_report.html)

+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 


