### PR TITLE
Only prod gets prod env vars

### DIFF
--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -72,11 +72,13 @@ set_cf_envs()
         continue
     fi
 
-    if [[ "$var_name" =~ "PROD_" ]] && [[ "$CF_SPACE" = "tanf-prod" ]]; then
+    if [[ "$var_name" =~ "PROD_" ]]; then
+      if [[ "$CF_SPACE" = "tanf-prod" ]]; then
         prod_var_name=$(echo $var_name | sed -e 's/PROD_//g')
         cf_cmd="cf set-env $CGAPPNAME_BACKEND $prod_var_name ${!var_name}"
+      else # if var starts with `PROD_` but CF_SPACE is anything else, do not set
+        continue
     else
-    
         cf_cmd="cf set-env $CGAPPNAME_BACKEND $var_name ${!var_name}"
     fi
     


### PR DESCRIPTION
## Summary of Changes
Tweaking `deploy-backend.sh` to not set prod values in non-prod places because we have our prod secrets and settings in our `tanf-dev` apps which is not only clutter and confusing but bad OpsSec. 

### Testing
Testing will be to use our deploy labels against a deployed site where these `PROD_` vars have been manually unset and ascertain that they don't get set again.