### PR TITLE
Introducing technical debt, too complex to fix tanf-dev

### DIFF
--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -117,11 +117,10 @@ bind_backend_to_services() {
       #       Introducing technical debt for release 3.0.0 specifically.
       env="develop"
     fi
-    
+
     cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-${env}"
     cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-${env}"
     cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-${env}"
-
     
     # The below command is different because they cannot be shared like the 3 above services
     cf bind-service "$CGAPPNAME_BACKEND" "es-${backend_app_name}"
@@ -131,7 +130,6 @@ bind_backend_to_services() {
     echo "Restarting app: $CGAPPNAME_BACKEND"
     cf restage "$CGAPPNAME_BACKEND"
 }
-
 
 ##############################
 # Main script body

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -110,9 +110,19 @@ update_backend()
 
 bind_backend_to_services() {
     echo "Binding services to app: $CGAPPNAME_BACKEND"
-    cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-${env}"
-    cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-${env}"
-    cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-${env}"
+
+    if [ "$CFAPPNAME_BACKEND" = "tdp-backend-develop" ]; then
+      # TODO: this is technical debt, we should either make staging mimic tanf-dev 
+      #       or make unique services for all apps but we have a services limit
+      #       Introducing technical debt for release 3.0.0 specifically.
+      cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-develop" 
+      cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-develop"
+      cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-develop"
+    else
+      cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-${env}"
+      cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-${env}"
+      cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-${env}"
+    fi
     
     # The below command is different because they cannot be shared like the 3 above services
     cf bind-service "$CGAPPNAME_BACKEND" "es-${backend_app_name}"
@@ -122,6 +132,7 @@ bind_backend_to_services() {
     echo "Restarting app: $CGAPPNAME_BACKEND"
     cf restage "$CGAPPNAME_BACKEND"
 }
+
 
 ##############################
 # Main script body

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -115,14 +115,13 @@ bind_backend_to_services() {
       # TODO: this is technical debt, we should either make staging mimic tanf-dev 
       #       or make unique services for all apps but we have a services limit
       #       Introducing technical debt for release 3.0.0 specifically.
-      cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-develop" 
-      cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-develop"
-      cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-develop"
-    else
-      cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-${env}"
-      cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-${env}"
-      cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-${env}"
+      env="develop"
     fi
+    
+    cf bind-service "$CGAPPNAME_BACKEND" "tdp-staticfiles-${env}"
+    cf bind-service "$CGAPPNAME_BACKEND" "tdp-datafiles-${env}"
+    cf bind-service "$CGAPPNAME_BACKEND" "tdp-db-${env}"
+
     
     # The below command is different because they cannot be shared like the 3 above services
     cf bind-service "$CGAPPNAME_BACKEND" "es-${backend_app_name}"


### PR DESCRIPTION
## Summary of Changes
After troubleshooting this morning, discovered that `tdp-backend-develop` was getting bound to staging services. Unfortunately, we didn't setup staging services like `tanf-dev` so it was not able to connect to database on startup:

```
  2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR Traceback (most recent call last):
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/app/manage.py", line 31, in <module>
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR main()
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/app/manage.py", line 27, in main
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR execute_from_command_line(sys.argv)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR utility.execute()
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/core/management/__init__.py", line 363, in execute
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR settings.INSTALLED_APPS
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/conf/__init__.py", line 82, in __getattr__
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR self._setup(name)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/conf/__init__.py", line 69, in _setup
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR self._wrapped = Settings(settings_module)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/conf/__init__.py", line 170, in __init__
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR mod = importlib.import_module(self.SETTINGS_MODULE)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR return _bootstrap._gcd_import(name[level:], package, level)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap_external>", line 883, in exec_module
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/settings/__init__.py", line 8, in <module>
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR from .celery import app as celery_app
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/settings/celery.py", line 12, in <module>
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR configurations.setup()
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/configurations/__init__.py", line 31, in setup
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR _setup()
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/configurations/__init__.py", line 17, in _setup
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR django.setup()
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/__init__.py", line 19, in setup
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/conf/__init__.py", line 82, in __getattr__
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR self._setup(name)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/conf/__init__.py", line 69, in _setup
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR self._wrapped = Settings(settings_module)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/django/conf/__init__.py", line 170, in __init__
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR mod = importlib.import_module(self.SETTINGS_MODULE)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR return _bootstrap._gcd_import(name[level:], package, level)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 672, in _load_unlocked
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "<frozen importlib._bootstrap>", line 632, in _load_backward_compatible
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/site-packages/configurations/importer.py", line 153, in load_module
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR mod = imp.load_module(fullname, *self.location)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/imp.py", line 235, in load_module
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR return load_source(name, filename, file)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/deps/1/python/lib/python3.10/imp.py", line 172, in load_source
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR module = _load(spec)
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/settings/cloudgov.py", line 29, in <module>
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR class CloudGov(Common):
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/settings/cloudgov.py", line 74, in CloudGov
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR db_name = database_creds['db_name'] if (cloudgov_space_suffix in ["prod",  "staging"]) else env_based_db_name
   2023-02-06T10:08:17.63-0500 [APP/PROC/WEB/0] ERR KeyError: 'db_name'
   2023-02-06T10:09:16.97-0500 [HEALTH/0] ERR Timed out after 1m0s (30 attempts) waiting for readiness check to succeed: failed to make TCP connection to 10.255.54.18:8080: dial tcp 10.255.54.18:8080: connect: connection refused
   2023-02-06T10:09:16.97-0500 [CELL/0] ERR Failed after 1m0.294s: readiness health check never passed.
   2023-02-06T10:09:16.98-0500 [CELL/SSHD/0] OUT Exit status 0
   2023-02-06T10:09:33.23-0500 [CELL/0] OUT Cell b701ee4f-885a-4c07-80c1-036e3d494e0a stopping instance 60e10116-1405-452b-5a76-846c
   2023-02-06T10:09:33.23-0500 [CELL/0] OUT Cell b701ee4f-885a-4c07-80c1-036e3d494e0a destroying container for instance 60e10116-1405-452b-5a76-846c
   2023-02-06T10:09:33.31-0500 [API/1] OUT Process has crashed with type: "web"
   2023-02-06T10:09:33.39-0500 [PROXY/0] OUT Exit status 137
```

Services:
```
ajameson@G6D61549VJ-ajameson-Raft tdrs-backend % cf services
Getting services in org hhs-acf-ofa / space tanf-staging as ajameson@teamraft.com...

name                      service                     plan                   bound apps                                 last operation     broker                   upgrade available
es-develop                aws-elasticsearch           es-dev                 tdp-backend-develop                        create succeeded   aws-broker               
es-staging                aws-elasticsearch           es-dev                 tdp-backend-staging                        create succeeded   aws-broker               
tanf-keys                 cloud-gov-service-account   space-deployer                                                    create succeeded   uaa-credentials-broker   
tdp-datafiles-develop     s3                          basic-sandbox                                                     create succeeded   s3-broker                
tdp-datafiles-staging     s3                          basic-sandbox          tdp-backend-develop, tdp-backend-staging   create succeeded   s3-broker                
tdp-db-develop            aws-rds                     micro-psql                                                        create succeeded   aws-broker               
tdp-db-staging            aws-rds                     micro-psql             tdp-backend-develop, tdp-backend-staging   create succeeded   aws-broker               
tdp-staticfiles-develop   s3                          basic-public-sandbox                                              create succeeded   s3-broker                
tdp-staticfiles-staging   s3                          basic-public-sandbox   tdp-backend-develop, tdp-backend-staging   create succeeded   s3-broker                
tdp-tf-states             s3                          basic-sandbox                                                     create succeeded   s3-broker                
```
