### PR TITLE
Changing flow if initial user and superuser

### DIFF
--- a/tdrs-backend/tdpservice/users/api/login.py
+++ b/tdrs-backend/tdpservice/users/api/login.py
@@ -137,15 +137,17 @@ class TokenAuthorizationOIDC(ObtainAuthToken):
             # user's `sub` UUID from the decoded payload, with which we will
             # authenticate later.
             initial_user = CustomAuthentication.authenticate(username=email)
+            logging.debug("initial_user obj:{}".format(initial_user))
 
-            if initial_user.login_gov_uuid is None:
-                # Save the `sub` to the superuser.
-                initial_user.login_gov_uuid = sub
-                initial_user.save()
+            if initial_user is not None:
+                if initial_user.login_gov_uuid is None:
+                    # Save the `sub` to the superuser.
+                    initial_user.login_gov_uuid = sub
+                    initial_user.save()
 
-                # Login with the new superuser.
-                self.login_user(request, initial_user, login_msg)
-                return initial_user
+                    # Login with the new superuser.
+                    self.login_user(request, initial_user, login_msg)
+                    return initial_user
 
         auth_options = self.get_auth_options(access_token=access_token, sub=sub)
         logging.debug("auth_options: {}".format(auth_options))


### PR DESCRIPTION
## Summary of Changes
Been running into issues in the deployed environment. Trying to debug and fix this for myself -- need this PR to deploy.

This appears to resolve my issue:
```
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR [2023-03-14 18:03:48,832 ERROR login.py::get:L266 :  Error attempting to login/register user:  'NoneType' object has no attribute 'login_gov_uuid' at...
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR Traceback (most recent call last):
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/users/api/login.py", line 231, in get
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR user = self.handle_user(request, id_token, decoded_payload)
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/users/api/login.py", line 141, in handle_user
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR if initial_user.login_gov_uuid is None:
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR AttributeError: 'NoneType' object has no attribute 'login_gov_uuid'
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR Error attempting to login/register user:  'NoneType' object has no attribute 'login_gov_uuid' at...
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR Traceback (most recent call last):
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/users/api/login.py", line 231, in get
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR user = self.handle_user(request, id_token, decoded_payload)
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR File "/home/vcap/app/tdpservice/users/api/login.py", line 141, in handle_user
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR if initial_user.login_gov_uuid is None:
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR AttributeError: 'NoneType' object has no attribute 'login_gov_uuid'
   2023-03-14T14:03:48.83-0400 [APP/PROC/WEB/0] ERR WARNING Bad Request: /v1/login/
```

By checking for None first, we don't have this uncaught attribute which I suppose could be handled with a try-catch. Letting this fall through to the account creation prevents this weirdness around *only* the superuser.