### PR TITLE
Revert "Filter User by STT/Region"

### DIFF
--- a/tdrs-backend/tdpservice/users/admin.py
+++ b/tdrs-backend/tdpservice/users/admin.py
@@ -35,12 +35,7 @@ class UserAdmin(admin.ModelAdmin):
     exclude = ['password', 'user_permissions', 'is_active']
     readonly_fields = ['last_login', 'date_joined', 'login_gov_uuid', 'hhs_id', 'access_request', 'deactivated']
     form = UserForm
-    list_filter = ('account_approval_status', 'stt', 'region')
-    list_display = [
-        "username",
-        'location',
-        "account_approval_status"
-    ]
+    list_filter = ('account_approval_status',)
     autocomplete_fields = ['stt']
 
     def has_add_permission(self, request):

--- a/tdrs-backend/tdpservice/users/models.py
+++ b/tdrs-backend/tdpservice/users/models.py
@@ -175,11 +175,6 @@ class User(AbstractUser):
         """Check if the user's account status has been set to 'Deactivated'."""
         return self.account_approval_status == AccountApprovalStatusChoices.DEACTIVATED
 
-    @property
-    def location(self):
-        """Return the STT or Region based on which is not null."""
-        return self.stt if self.stt else self.region
-
     @classmethod
     def from_db(cls, db, field_names, values):
         """Override the django Model from_db method.

--- a/tdrs-backend/tdpservice/users/test/test_models.py
+++ b/tdrs-backend/tdpservice/users/test/test_models.py
@@ -3,8 +3,6 @@ from django.core.exceptions import ValidationError
 
 import pytest
 
-from tdpservice.stts.models import STT, Region
-
 
 @pytest.mark.django_db
 def test_user_string_representation(user):
@@ -51,14 +49,6 @@ def test_is_deactivated_user_property(user, deactivated_user):
     """Test `is_deactivated` property returns `True` when `account_approval_status` is 'Deactivated'."""
     assert user.is_deactivated is False
     assert deactivated_user.is_deactivated is True
-
-
-@pytest.mark.django_db
-def test_location_user_property(stt_user, regional_user, stt):
-    """Test `location` property returns non-null models.Model representing Region or STT."""
-    stt_user.stt = stt
-    assert isinstance(stt_user.location, STT)
-    assert isinstance(regional_user.location, Region)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Reverts raft-tech/TANF-app#2471

Looks like we merged early prior to running through [QASP process](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-workflow.md#the-issue-is-ready-for-qasp-review). Reverting these minor changes until Alex is able to review it.