### PR TITLE
using ref_name for simplified branch name

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -64,5 +64,5 @@ jobs:
         with:
           user-token: ${{ secrets.CIRCLE_CI_V2_TOKEN }}
           project-slug: ${{ github.repository }}
-          branch: ${{ github.ref }}
+          branch: ${{ github.ref_name }}
           payload: '{"build_and_test_all": true}'

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -64,5 +64,5 @@ jobs:
         with:
           user-token: ${{ secrets.CIRCLE_CI_V2_TOKEN }}
           project-slug: ${{ github.repository }}
-          branch: ${{ github.ref_name }}
+          branch: ${{ (github.event_name == 'pull_request') && github.head_ref || github.ref_name }}
           payload: '{"build_and_test_all": true}'

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -40,5 +40,5 @@ jobs:
       with:
         user-token: ${{ secrets.CIRCLE_CI_V2_TOKEN }}
         project-slug: ${{ github.repository }}
-        branch: ${{ github.ref }}
+        branch: ${{ github.ref_name }}
         payload: '{"build_and_test_backend": true}'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -42,4 +42,3 @@ jobs:
         project-slug: ${{ github.repository }}
         branch: ${{ github.ref_name }}
         payload: '{"build_and_test_frontend": true}'
-        

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -40,6 +40,6 @@ jobs:
       with:
         user-token: ${{ secrets.CIRCLE_CI_V2_TOKEN }}
         project-slug: ${{ github.repository }}
-        branch: ${{ github.ref }}
+        branch: ${{ github.ref_name }}
         payload: '{"build_and_test_frontend": true}'
         

--- a/.github/workflows/deploy-develop-on-merge.yml
+++ b/.github/workflows/deploy-develop-on-merge.yml
@@ -44,5 +44,5 @@ jobs:
       with:
         user-token: ${{ secrets.CIRCLE_CI_V2_TOKEN }}
         project-slug: ${{ github.repository }}
-        branch: ${{ github.ref }}
+        branch: ${{ github.ref_name }}
         payload: '{"develop_branch_deploy": true, "target_env": "develop"}'

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -40,6 +40,6 @@ jobs:
         with:
           user-token: ${{ secrets.CIRCLE_CI_V2_TOKEN }}
           project-slug: ${{ github.repository }}
-          branch: ${{ github.ref }}
+          branch: ${{ github.ref_name }}
           payload: '{"deploy_infrastructure": true}'
           


### PR DESCRIPTION
This is a quick fix so branches report their simplified $BRANCH_NAME on CircleCI vs refs/heads/$BRANCH_NAME