### PR TITLE
[DRAFT] Connect to managed redis service

### DIFF
--- a/tdrs-backend/tdpservice/settings/celery.py
+++ b/tdrs-backend/tdpservice/settings/celery.py
@@ -20,14 +20,14 @@ app = Celery('settings')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # disable ssl verification
-app.conf.update(
-    broker_use_ssl={
-        'ssl_cert_reqs': ssl.CERT_NONE,
-    },
-    redis_backend_use_ssl={
-        'ssl_cert_reqs': ssl.CERT_NONE,
-    },
-)
+# app.conf.update(
+#     broker_use_ssl={
+#         'ssl_cert_reqs': ssl.CERT_NONE,
+#     },
+#     redis_backend_use_ssl={
+#         'ssl_cert_reqs': ssl.CERT_NONE,
+#     },
+# )
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()

--- a/tdrs-backend/tdpservice/settings/celery.py
+++ b/tdrs-backend/tdpservice/settings/celery.py
@@ -20,14 +20,14 @@ app = Celery('settings')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # disable ssl verification
-# app.conf.update(
-#     broker_use_ssl={
-#         'ssl_cert_reqs': ssl.CERT_NONE,
-#     },
-#     redis_backend_use_ssl={
-#         'ssl_cert_reqs': ssl.CERT_NONE,
-#     },
-# )
+app.conf.update(
+    broker_use_ssl={
+        'ssl_cert_reqs': ssl.CERT_NONE,
+    },
+    redis_backend_use_ssl={
+        'ssl_cert_reqs': ssl.CERT_NONE,
+    },
+)
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()

--- a/tdrs-backend/tdpservice/settings/celery.py
+++ b/tdrs-backend/tdpservice/settings/celery.py
@@ -1,6 +1,7 @@
 """Celery configuration file."""
 from __future__ import absolute_import
 import os
+import ssl
 import configurations
 from celery import Celery
 
@@ -17,5 +18,16 @@ app = Celery('settings')
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
 app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# disable ssl verification
+app.conf.update(
+    broker_use_ssl={
+        'ssl_cert_reqs': ssl.CERT_NONE,
+    },
+    redis_backend_use_ssl={
+        'ssl_cert_reqs': ssl.CERT_NONE,
+    },
+)
+
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()

--- a/tdrs-backend/tdpservice/settings/cloudgov.py
+++ b/tdrs-backend/tdpservice/settings/cloudgov.py
@@ -146,6 +146,13 @@ class CloudGov(Common):
         },
     }
 
+    # Redis
+    REDIS_URI = cloudgov_services['aws-elasticache-redis']['credentials']['uri']
+    logger.debug("REDIS_URI: " + REDIS_URI)
+
+    CELERY_BROKER_URL = REDIS_URI + '/0'
+    CELERY_RESULT_BACKEND = REDIS_URI + '/1'
+
 
 class Development(CloudGov):
     """Settings for applications deployed in the Cloud.gov dev space."""

--- a/tdrs-backend/tdpservice/settings/cloudgov.py
+++ b/tdrs-backend/tdpservice/settings/cloudgov.py
@@ -147,7 +147,8 @@ class CloudGov(Common):
     }
 
     # Redis
-    REDIS_URI = cloudgov_services['aws-elasticache-redis'][0]['credentials']['uri']
+    redis_settings = cloudgov_services['aws-elasticache-redis'][0]['credentials']
+    REDIS_URI = f"rediss://{redis_settings['password']}@{redis_settings['host']}:{redis_settings['port']}"
     logger.debug("REDIS_URI: " + REDIS_URI)
 
     CELERY_BROKER_URL = REDIS_URI + '/0'

--- a/tdrs-backend/tdpservice/settings/cloudgov.py
+++ b/tdrs-backend/tdpservice/settings/cloudgov.py
@@ -148,7 +148,7 @@ class CloudGov(Common):
 
     # Redis
     redis_settings = cloudgov_services['aws-elasticache-redis'][0]['credentials']
-    REDIS_URI = f"rediss://{redis_settings['password']}@{redis_settings['host']}:{redis_settings['port']}"
+    REDIS_URI = f"rediss://:{redis_settings['password']}@{redis_settings['host']}:{redis_settings['port']}"
     logger.debug("REDIS_URI: " + REDIS_URI)
 
     CELERY_BROKER_URL = REDIS_URI + '/0'

--- a/tdrs-backend/tdpservice/settings/cloudgov.py
+++ b/tdrs-backend/tdpservice/settings/cloudgov.py
@@ -147,7 +147,7 @@ class CloudGov(Common):
     }
 
     # Redis
-    REDIS_URI = cloudgov_services['aws-elasticache-redis']['credentials']['uri']
+    REDIS_URI = cloudgov_services['aws-elasticache-redis'][0]['credentials']['uri']
     logger.debug("REDIS_URI: " + REDIS_URI)
 
     CELERY_BROKER_URL = REDIS_URI + '/0'


### PR DESCRIPTION
## Summary of Changes

`tdp-sandbox-backend` is now bound to a cloud.gov managed redis service. These changes allow the app/celery to connect and use the service as a broker.

Cloud.gov deploys redis with ssl enabled, but the `uri` provided in VCAP Services doesn't use the ssl scheme (`redis://` vs `rediss://`) so we have to rebuild from the individual parts.

Additionally, since we don't have access to the ssl certificates cloud.gov installs on the redis service, we have to turn `ssl_cert_reqs` off for the broker and backend. This disables ssl certificate verification

This is buried somewhere in the [celery docs](https://docs.celeryq.dev/en/stable/userguide/configuration.html) (it's hard to link to specific sections, sorry)
> When using a TLS connection (protocol is rediss://), you may pass in all values in [broker_use_ssl](https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_use_ssl) as query parameters. Paths to certificates must be URL encoded, and ssl_cert_reqs is required.

and 

> ssl_cert_reqs (required): one of the SSLContext.verify_mode values:
>    * ssl.CERT_NONE
>    * ssl.CERT_OPTIONAL
>    * ssl.CERT_REQUIRED

But this comment got me pointed in the right direction.
* https://github.com/fecgov/openFEC/issues/4358#issuecomment-637892900
