### PR TITLE
setup can trigger by circleci for develop branch for nightly scans to…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
           filters:
             branches:
               only:
+                - develop
                 - main
                 - master
                 - /^release.*/      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ workflows:
           filters:
             branches:
               only:
-                - hotfix/nightly-scan
                 - develop
                 - main
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
           filters:
             branches:
               only:
+                - hotfix/nightly-scan
                 - develop
                 - main
                 - master


### PR DESCRIPTION
Hot fix to allow circleci to trigger setup for develop branch which will allow the nightly scan to run