### PR TITLE
2751 the resource cards updated with the latest coding instructions

### DIFF
--- a/tdrs-frontend/src/components/ResourceCards/ResourceCards.jsx
+++ b/tdrs-frontend/src/components/ResourceCards/ResourceCards.jsx
@@ -70,7 +70,7 @@ function ResourceCards() {
                 buttonId="viewACFFormInstructions"
                 title="ACF-199 and ACF-209 Instructions"
                 body="Instructions and definitions for completion of forms ACF-199 (TANF Data Report) and ACF-209 (SSP-MOE Data Report)."
-                link="https://www.acf.hhs.gov/sites/default/files/documents/ofa/tanf_data_reports_tan_ssp_instructions_definitions.pdf"
+                link="https://www.acf.hhs.gov/ofa/policy-guidance/acf-ofa-pi-23-04"
                 linkText="View ACF Form Instructions"
               />
             </li>

--- a/tdrs-frontend/src/components/ResourceCards/ResourceCards.test.js
+++ b/tdrs-frontend/src/components/ResourceCards/ResourceCards.test.js
@@ -84,7 +84,7 @@ describe('ResourceCards', () => {
     const store = mockStore(initialState)
 
     const url =
-      'https://www.acf.hhs.gov/sites/default/files/documents/ofa/tanf_data_reports_tan_ssp_instructions_definitions.pdf'
+      'https://www.acf.hhs.gov/ofa/policy-guidance/acf-ofa-pi-23-04'
 
     const wrapper = mount(
       <Provider store={store}>

--- a/tdrs-frontend/src/components/ResourceCards/ResourceCards.test.js
+++ b/tdrs-frontend/src/components/ResourceCards/ResourceCards.test.js
@@ -83,8 +83,7 @@ describe('ResourceCards', () => {
   it('redirects to ACF Form Instructions when View ACF Form Instructions clicked', () => {
     const store = mockStore(initialState)
 
-    const url =
-      'https://www.acf.hhs.gov/ofa/policy-guidance/acf-ofa-pi-23-04'
+    const url = 'https://www.acf.hhs.gov/ofa/policy-guidance/acf-ofa-pi-23-04'
 
     const wrapper = mount(
       <Provider store={store}>


### PR DESCRIPTION
## Summary of Changes

Pull request closes #2751 _

Update ACF-199 card link on the homepage.

## How to Test

Browse frontend and click on the link in ACF-199 card. 

## Deliverables
_More details on how deliverables herein are assessed included [here](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [x] resource card points to latest tanf/ssp instructions when logged and not logged in. 
+ [x] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [x] If this PR introduces backend code changes, are they meaningfully tested?
  + [x] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [x] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [x] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [x] Are backend code style checks passing on CircleCI?
+ [x] Are frontend code style checks passing on CircleCI?
+ [x] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic? 
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review? 
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?


### [Deliverable 5: Deployed](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [x] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [x] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [x] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [x] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 

### [Deliverable 8: User Research](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

Research product(s) clearly articulate(s):
+ [ ] the purpose of the research
+ [ ] methods used to conduct the research 
+ [ ] who participated in the research
+ [ ] what was tested and how
+ [ ] impact of research on TDP
+ [ ] (_if applicable_) final design mockups produced for TDP development 


