### PR TITLE
Hotfix - node version unavailable

### DIFF
--- a/.circleci/build-and-test/commands.yml
+++ b/.circleci/build-and-test/commands.yml
@@ -38,6 +38,7 @@
           command: |
             sudo apt-get update
             sudo apt-get install -y libgbm-dev
+            export NVM_NODEJS_ORG_MIRROR='https://registry.npmjs.org/'
             source /opt/circleci/.nvm/nvm.sh
             nvm install v16.13
             nvm alias default v16.13

--- a/.circleci/build-and-test/commands.yml
+++ b/.circleci/build-and-test/commands.yml
@@ -40,8 +40,8 @@
             sudo apt-get install -y libgbm-dev
             export NVM_NODEJS_ORG_MIRROR='https://registry.npmjs.org/'
             source /opt/circleci/.nvm/nvm.sh
-            nvm install v16.13
-            nvm alias default v16.13
+            nvm install v16.13.2
+            nvm alias default v16.13.2
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
             echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 

--- a/.circleci/build-and-test/commands.yml
+++ b/.circleci/build-and-test/commands.yml
@@ -36,6 +36,7 @@
       - run:
           name: Install Node.JS
           command: |
+            echo "Are we entering command block?"
             sudo apt-get update
             sudo apt-get install -y libgbm-dev
             export NVM_NODEJS_ORG_MIRROR='https://registry.npmjs.org/'

--- a/.circleci/build-and-test/commands.yml
+++ b/.circleci/build-and-test/commands.yml
@@ -39,10 +39,9 @@
             echo "Are we entering command block?"
             sudo apt-get update
             sudo apt-get install -y libgbm-dev
-            export NVM_NODEJS_ORG_MIRROR='https://registry.npmjs.org/'
             source /opt/circleci/.nvm/nvm.sh
-            nvm install v16.13.2
-            nvm alias default v16.13.2
+            nvm install v16.13
+            nvm alias default v16.13
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
             echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 


### PR DESCRIPTION
## Summary of Changes
Running into [pipeline failures](https://app.circleci.com/pipelines/github/raft-tech/TANF-app/28688/workflows/0d7c6615-f168-4c41-b045-f573153fcf9f/jobs/84537) when attempting to install v16 of nodejs on the frontend:

```
=> Appending nvm source string to /root/.bashrc
=> Appending bash_completion source string to /root/.bashrc
=> Close and reopen your terminal to start using nvm or run the following to use it now:

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
Version '16.13' not found - try `nvm ls-remote` to browse available versions.

Exited with code exit status 3

CircleCI received exit code 3
```