### PR TITLE
PG Client Hotfix

### DIFF
--- a/tdrs-backend/Dockerfile
+++ b/tdrs-backend/Dockerfile
@@ -14,11 +14,6 @@ WORKDIR /tdpapp/
 RUN apt-get -y update
 # Upgrade already installed packages:
 RUN apt-get -y upgrade
-# Postgres client setup
-RUN apt --purge remove postgresql postgresql-* && apt install -y postgresql-common curl ca-certificates && install -d /usr/share/postgresql-common/pgdg && \
-curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
-sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-apt -y update && apt install postgresql-client-15 -y
 # Install packages:
 RUN apt install -y gcc graphviz graphviz-dev libpq-dev python3-dev vim
 # Install pipenv

--- a/tdrs-backend/Dockerfile
+++ b/tdrs-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8-slim-buster
+FROM python:3.10.8-slim-bullseye
 ENV PYTHONUNBUFFERED 1
 
 ARG user=tdpuser
@@ -14,6 +14,11 @@ WORKDIR /tdpapp/
 RUN apt-get -y update
 # Upgrade already installed packages:
 RUN apt-get -y upgrade
+# Postgres client setup
+RUN apt --purge remove postgresql postgresql-* && apt install -y postgresql-common curl ca-certificates && install -d /usr/share/postgresql-common/pgdg && \
+curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+apt -y update && apt install postgresql-client-15 -y
 # Install packages:
 RUN apt install -y gcc graphviz graphviz-dev libpq-dev python3-dev vim
 # Install pipenv

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -50,8 +50,8 @@ data "cloudfoundry_service" "rds" {
 resource "cloudfoundry_service_instance" "database" {
   name             = "tdp-db-dev"
   space            = data.cloudfoundry_space.space.id
-  service_plan     = data.cloudfoundry_service.rds.service_plans["medium-gp-psql"]
-  json_params      = "{\"version\": \"15\", \"storage_type\": \"gp3\", \"storage\": 50}"
+  service_plan     = data.cloudfoundry_service.rds.service_plans["micro-psql"]
+  json_params      = "{\"version\": \"15\"}"
   recursive_delete = true
   timeouts {
     create = "60m"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -50,8 +50,8 @@ data "cloudfoundry_service" "rds" {
 resource "cloudfoundry_service_instance" "database" {
   name             = "tdp-db-dev"
   space            = data.cloudfoundry_space.space.id
-  service_plan     = data.cloudfoundry_service.rds.service_plans["micro-psql"]
-  json_params      = "{\"version\": \"15\"}"
+  service_plan     = data.cloudfoundry_service.rds.service_plans["medium-gp-psql"]
+  json_params      = "{\"version\": \"15\", \"storage_type\": \"gp3\", \"storage\": 50}"
   recursive_delete = true
   timeouts {
     create = "60m"


### PR DESCRIPTION
## Summary of Changes
- Update base linux image

## How to Test
_List the steps to test the PR_
These steps are generic, please adjust as necessary.
```
cd tdrs-frontend && docker-compose up
cd tdrs-backend && docker-compose up --build
```

1. Make sure the container builds and starts

## Deliverables
_More details on how deliverables herein are assessed included [here](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [ ] [**_insert ACs here_**]
+ [ ] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [ ] If this PR introduces backend code changes, are they meaningfully tested?
  + [ ] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [ ] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [ ] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [ ] Are backend code style checks passing on CircleCI?
+ [ ] Are frontend code style checks passing on CircleCI?
+ [ ] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic? 
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review? 
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?


### [Deliverable 5: Deployed](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [ ] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [ ] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [ ] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [ ] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 

### [Deliverable 8: User Research](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

Research product(s) clearly articulate(s):
+ [ ] the purpose of the research
+ [ ] methods used to conduct the research 
+ [ ] who participated in the research
+ [ ] what was tested and how
+ [ ] impact of research on TDP
+ [ ] (_if applicable_) final design mockups produced for TDP development 


