### PR TITLE
Fixes doc formatting issue

### DIFF
--- a/docs/User-Experience/Research-Syntheses/2020, Summer - Understanding Stakeholders and creating personas.md
+++ b/docs/User-Experience/Research-Syntheses/2020, Summer - Understanding Stakeholders and creating personas.md
@@ -1,4 +1,4 @@
-![image](https://github.com/user-attachments/assets/97e8fbf1-954b-4f3b-9000-ecb3b0f1d0d9)![image](https://github.com/user-attachments/assets/39a7b775-2771-438f-a270-d09dc263ef3c)# Stakeholders and Personas
+# Stakeholders and Personas
 
 Last updated for [Issue #3100](https://github.com/raft-tech/TANF-app/issues/3100)
 


### PR DESCRIPTION
## Summary of Changes
A screenshot (pictured) got accidentally inserted to the personas doc somewhere along the line, this removes it and fixes the H1 heading. 

![image](https://github.com/user-attachments/assets/be450c40-3499-4837-a1a5-5356cc2f1916)
(Requesting access | Equipment | # is the screenshot)