### PR TITLE
Hotfix - celery deployments

### DIFF
--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -112,13 +112,6 @@ set_alloy_envs() {
 }
 
 add_service_bindings() {
-    if [ "$CGAPPNAME_BACKEND" = "tdp-backend-develop" ]; then
-      # TODO: this is technical debt, we should either make staging mimic tanf-dev
-      #       or make unique services for all apps but we have a services limit
-      #       Introducing technical debt for release 3.0.0 specifically.
-      env="develop"
-    fi
-
     yq eval -i ".applications[0].services[0] = \"tdp-db-${env}\"" ./tdrs-backend/manifest.buildpack.yml
     yq eval -i ".applications[0].services[1] = \"tdp-staticfiles-${env}\"" ./tdrs-backend/manifest.buildpack.yml
     yq eval -i ".applications[0].services[2] = \"tdp-datafiles-${env}\"" ./tdrs-backend/manifest.buildpack.yml
@@ -177,11 +170,10 @@ update_backend()
           cf unset-env "$APP" "APP_DB_NAME"
           cf set-env "$APP" "APP_DB_NAME" "tdp_db_$backend_app_name"
         fi
-
-        cf set-env "$APP" CGAPPNAME_BACKEND "$CGAPPNAME_BACKEND"
-
-        cf restage "$APP"
     fi
+
+    cf set-env "$APP" CGAPPNAME_BACKEND "$CGAPPNAME_BACKEND"
+    cf restage "$APP"
 
     cd ..
 }

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -36,9 +36,3 @@ variable "cf_user" {
   type        = string
   description = "secret; cloud.gov deployer account user"
 }
-
-variable "dev_app_names" {
-  type        = list(string)
-  description = "list of app names deployed in the dev environment"
-  default     = ["a11y", "qasp", "raft"]
-}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -91,9 +91,7 @@ data "cloudfoundry_service" "redis" {
 }
 
 resource "cloudfoundry_service_instance" "redis" {
-  for_each     = toset(var.dev_app_names)
   name         = "tdp-redis-prod"
   space        = data.cloudfoundry_space.space.id
-  # service_plan = data.cloudfoundry_service.redis.service_plans["redis-3node"]
-  service_plan = data.cloudfoundry_service.redis.service_plans["redis-dev"]
+  service_plan = data.cloudfoundry_service.redis.service_plans["redis-3node"]
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -91,9 +91,7 @@ data "cloudfoundry_service" "redis" {
 }
 
 resource "cloudfoundry_service_instance" "redis" {
-  for_each     = toset(var.dev_app_names)
   name         = "tdp-redis-staging"
   space        = data.cloudfoundry_space.space.id
-  # service_plan = data.cloudfoundry_service.redis.service_plans["redis-3node"]
-  service_plan = data.cloudfoundry_service.redis.service_plans["redis-dev"]
+  service_plan = data.cloudfoundry_service.redis.service_plans["redis-3node"]
 }


### PR DESCRIPTION
## Summary of Changes
Adds the following hotfixes to Release 3.8.8 to fix redis deployments to the `tanf-staging` space
* #5169 
* #5171 