### PR TITLE
Datetime Field Type for EXIT_MONTH in Xlsx Files Causing Parsing Failure

### DIFF
--- a/tdrs-backend/tdpservice/parsers/fields.py
+++ b/tdrs-backend/tdpservice/parsers/fields.py
@@ -55,20 +55,34 @@ class Field:
         """Return a string representation of the field."""
         return f"{self.name}({self.position.start}-{self.position.end})"
 
-    def parse_value(self, row: RawRow):
-        """Parse the value for a field given a row, posiiton, and field type."""
-        value = row.value_at(self.position)
-        value_length = len(self.position)
+    def _get_raw_value(self, row: RawRow):
+        """Get the raw value for a field given a row."""
+        return row.value_at(self.position)
 
-        # We need the type check because the XLSX decoder returns typed data not strictly strings.
-        not_numeric = not isinstance(value, (int, float))
+    def _get_raw_value_length(self):
+        """Get the length of the raw value for a field."""
+        return len(self.position)
+
+    def _empty_check(self, value, value_length):
+        """Check if the value is empty."""
+        has_length = hasattr(value, "__len__")
         if value is None or (
-            not_numeric
+            has_length
             and (len(value) < value_length or value_is_empty(value, value_length))
         ):
             logger.debug(
                 f"Field: '{self.name}' at position: [{self.position.start}, {self.position.end}) is empty."
             )
+            return True
+        return False
+
+    def parse_value(self, row: RawRow):
+        """Parse the value for a field given a row, posiiton, and field type."""
+        value = self._get_raw_value(row)
+        value_length = self._get_raw_value_length()
+
+        # We need the type check because the XLSX decoder returns typed data not strictly strings.
+        if self._empty_check(value, value_length):
             return None
 
         match self.type:
@@ -87,7 +101,7 @@ class Field:
 
 
 class TransformField(Field):
-    """Represents a field that requires some transformation before serializing."""
+    """Represents a field that requires some transformation to the raw value before serializing."""
 
     def __init__(
         self,
@@ -119,8 +133,16 @@ class TransformField(Field):
         self.kwargs = kwargs
 
     def parse_value(self, row: RawRow):
-        """Parse and transform the value for a field given a row, position, and field type."""
-        value = super().parse_value(row)
+        """Parse and transform the value for a field given a row, position, and field type.
+
+        Does not call super().parse_value. All type coercion/error handling must be handled by transform_func.
+        """
+        value = self._get_raw_value(row)
+        value_length = self._get_raw_value_length()
+
+        if self._empty_check(value, value_length):
+            return None
+
         try:
             return_value = self.transform_func(value, **self.kwargs)
             return return_value

--- a/tdrs-backend/tdpservice/parsers/schema_defs/fra/te1.py
+++ b/tdrs-backend/tdpservice/parsers/schema_defs/fra/te1.py
@@ -1,5 +1,7 @@
 """Schema for FRA Work Outcome TANF Exiters records."""
 
+from datetime import datetime
+
 from tdpservice.parsers.constants import (
     INVALID_SSN_AREA_NUMBERS,
     INVALID_SSN_GROUP_NUMBERS,
@@ -9,10 +11,23 @@ from tdpservice.parsers.constants import (
     SSN_SERIAL_NUMBER_POSITION,
 )
 from tdpservice.parsers.dataclasses import FieldType, Position
-from tdpservice.parsers.fields import Field
+from tdpservice.parsers.fields import Field, TransformField
 from tdpservice.parsers.row_schema import FRASchema
 from tdpservice.parsers.validators import category1, category2
 from tdpservice.search_indexes.models.fra import TANF_Exiter1
+
+
+def tranform_exit_date(value, **kwargs):
+    """transform function to handle datetime to int coercion."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        # Note: No type check here to allow exception to bubble up instead of searching for a fake None type
+        return int(value)
+    if isinstance(value, datetime):
+        return int(value.strftime("%Y%m"))
+    return value
+
 
 te1 = [
     FRASchema(
@@ -22,15 +37,17 @@ te1 = [
             category1.validate_exit_date_against_fiscal_period(),
         ],
         fields=[
-            Field(
+            TransformField(
                 item="A",
                 name="EXIT_DATE",
                 friendly_name="Exit Date",
                 type=FieldType.NUMERIC,
-                position=Position(start=0),
+                startIndex=0,
+                endIndex=1,
                 required=True,
                 validators=[],
                 is_encrypted=False,
+                transform_func=tranform_exit_date,
             ),
             Field(
                 item="B",

--- a/tdrs-backend/tdpservice/parsers/schema_defs/fra/te1.py
+++ b/tdrs-backend/tdpservice/parsers/schema_defs/fra/te1.py
@@ -18,7 +18,7 @@ from tdpservice.search_indexes.models.fra import TANF_Exiter1
 
 
 def tranform_exit_date(value, **kwargs):
-    """transform function to handle datetime to int coercion."""
+    """Transform function to handle datetime to int coercion."""
     if isinstance(value, int):
         return value
     if isinstance(value, str):


### PR DESCRIPTION
## Summary of Changes
- Updated the TE1 schema to leverage the TransformField class to better handle type coercion when parsing XLSX datafiles
- Generalized the TransformField class further by updating it to have full control over value parsing, validation, and error handling
Pull request closes #5463

## How to Test

[DE Q2 TANF Exiters List_test (2025-Q2-Work Outcomes of TANF Exiters).xlsx](https://github.com/user-attachments/files/23552297/DE.Q2.TANF.Exiters.List_test.2025-Q2-Work.Outcomes.of.TANF.Exiters.xlsx)

1. Start your local instance on the `develop` branch first.
2. Submit the attached file and verify you see the same stack trace as below and that no records are created for the file
```
09:34:56.876: [APP/PROC/WEB.0] 2025-11-14 15:34:56,875 INFO parser_task.py::parse:L80 :
09:34:56.876: [APP/PROC/WEB.0] __ Starting to parse datafile None__
09:34:56.876: [APP/PROC/WEB.0] 
09:34:57.106: [APP/PROC/WEB.0] 2025-11-14 15:34:57,106 INFO decoders.py::get_suggested_decoder:L262 :  Returning XLSX decoder with a confidence score of 0.8
09:34:57.114: [APP/PROC/WEB.0] 2025-11-14 15:34:57,113 ERROR schema_manager.py::parse_and_validate:L45 :  Exception in SchemaManager.parse_and_validate
09:34:57.114: [APP/PROC/WEB.0] Traceback (most recent call last):
09:34:57.114: [APP/PROC/WEB.0] File "/home/vcap/app/tdpservice/parsers/schema_manager.py", line 41, in parse_and_validate
09:34:57.114: [APP/PROC/WEB.0] record, is_valid, errors = schema.parse_and_validate(row)
09:34:57.114: [APP/PROC/WEB.0] File "/home/vcap/app/tdpservice/parsers/row_schema.py", line 370, in parse_and_validate
09:34:57.114: [APP/PROC/WEB.0] record = self.parse_row(row)
09:34:57.114: [APP/PROC/WEB.0] File "/home/vcap/app/tdpservice/parsers/row_schema.py", line 61, in parse_row
09:34:57.114: [APP/PROC/WEB.0] value = field.parse_value(row)
09:34:57.114: [APP/PROC/WEB.0] File "/home/vcap/app/tdpservice/parsers/fields.py", line 67, in parse_value
09:34:57.114: [APP/PROC/WEB.0] and (len(value) < value_length or value_is_empty(value, value_length))
09:34:57.114: [APP/PROC/WEB.0] TypeError: object of type 'datetime.datetime' has no len()
09:34:57.231: [APP/PROC/WEB.0] 2025-11-14 15:34:57,231 INFO parser_task.py::parse:L173 :  DataFile parsing finished for file -> {id: 2802, filename: DE Q2 TANF Exiters List_test (2025-Q2-Work Outcomes of TANF Exiters).xlsx, STT: Delaware (10), S3 location: data_files/2025/Q2/8/Work Outcomes of TANF Exiters/DE_Q2_TANF_Exiters_List_test_2025-Q2-Work_Ou.xlsx}.
```
3. Switch to this branch
4. Submit the attached file and verify the file is parsed and the records are all created

## Deliverables
_More details on how deliverables herein are assessed included [here](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [ ] [**_insert ACs here_**]
+ [ ] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [ ] If this PR introduces backend code changes, are they meaningfully tested?
  + [ ] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [ ] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [ ] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [ ] Are backend code style checks passing on CircleCI?
+ [ ] Are frontend code style checks passing on CircleCI?
+ [ ] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic? 
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review? 
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?


### [Deliverable 5: Deployed](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [ ] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [ ] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [ ] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [ ] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 

### [Deliverable 8: User Research](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

Research product(s) clearly articulate(s):
+ [ ] the purpose of the research
+ [ ] methods used to conduct the research 
+ [ ] who participated in the research
+ [ ] what was tested and how
+ [ ] impact of research on TDP
+ [ ] (_if applicable_) final design mockups produced for TDP development 


