### PR TITLE
Hotfix: CircleCI Job Timeout

### DIFF
--- a/.circleci/deployment/commands.yml
+++ b/.circleci/deployment/commands.yml
@@ -96,6 +96,7 @@
             sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_amd64 && chmod +x /usr/local/bin/yq
       - run:
           name: Apply database config
+          no_output_timeout: 1h
           command: |
             bash ./scripts/apply-database-config.sh <<parameters.backend-appname>> <<parameters.cf-space>>
       - run:


### PR DESCRIPTION
## Summary of Changes
This has already been merged into [HHS:master](https://github.com/HHS/TANF-app/pull/617), but needs to get into develop and subsequently HHS:main. This change was added because a recently added migration (`data_files.0019_datafile_program_type`) took longer than 10 minutes to run which meant no output was logged to the console for CircleCI. Because of that, CircleCI was killing the job.

- Updated the `no_output_timeout` flag to the maximum allowed value for the HHS CircleCI service plan to help keep long running jobs alive. 

