### PR TITLE
Hotfix: Program Type Data Loss Fix

### DIFF
--- a/tdrs-backend/plg/grafana_views/generate_views.py
+++ b/tdrs-backend/plg/grafana_views/generate_views.py
@@ -16,14 +16,14 @@ CWD = os.path.dirname(os.path.abspath(__file__))
 
 query_template = """
 SELECT {fields}
-    data_files.program_type,
     data_files.section,
     data_files.version,
     data_files.year,
     data_files.quarter,
     stt.name AS "STT",                                                     -- Select stt_name from the stts table
     stt.stt_code AS "STT_CODE",                                            -- Select stt_code from the stts table
-    stt.region_id AS "REGION"                                              -- Select region from the stts table
+    stt.region_id AS "REGION",                                             -- Select region from the stts table
+    data_files.program_type
 FROM {table} {record_type}
 INNER JOIN
         data_files_datafile data_files                                     -- Join with data_files_datafile
@@ -34,18 +34,19 @@ INNER JOIN
             section,                                                       -- Select section
             year,                                                          -- Select fiscal_year
             quarter,                                                       -- Select fiscal_quarter
-            MAX(version) AS version                                        -- Get the maximum version for each group
+            MAX(version) AS version,                                       -- Get the maximum version for each group
+            program_type                                                   -- Select program_type
         FROM
             data_files_datafile                                            -- Subquery table
         GROUP BY
-            stt_id, section, year, quarter                                 -- Group by columns
+            stt_id, program_type, section, year, quarter                   -- Group by columns
     ) most_recent
         ON data_files.stt_id = most_recent.stt_id
-        AND data_files.program_type = most_recent.program_type,
         AND data_files.section = most_recent.section
         AND data_files.version = most_recent.version
         AND data_files.year = most_recent.year
         AND data_files.quarter = most_recent.quarter
+        AND data_files.program_type = most_recent.program_type
     INNER JOIN
         stts_stt stt                                                       -- Join with the stts table (aliased as stt)
         ON data_files.stt_id = stt.id                                      -- Join condition to match stt_id

--- a/tdrs-backend/plg/grafana_views/generate_views.py
+++ b/tdrs-backend/plg/grafana_views/generate_views.py
@@ -16,6 +16,7 @@ CWD = os.path.dirname(os.path.abspath(__file__))
 
 query_template = """
 SELECT {fields}
+    data_files.program_type,
     data_files.section,
     data_files.version,
     data_files.year,
@@ -40,6 +41,7 @@ INNER JOIN
             stt_id, section, year, quarter                                 -- Group by columns
     ) most_recent
         ON data_files.stt_id = most_recent.stt_id
+        AND data_files.program_type = most_recent.program_type,
         AND data_files.section = most_recent.section
         AND data_files.version = most_recent.version
         AND data_files.year = most_recent.year

--- a/tdrs-backend/tdpservice/data_files/admin/admin.py
+++ b/tdrs-backend/tdpservice/data_files/admin/admin.py
@@ -16,6 +16,7 @@ from tdpservice.data_files.admin.filters import LatestReparseEvent, VersionFilte
 from tdpservice.data_files.models import DataFile, LegacyFileTransfer
 from tdpservice.data_files.s3_client import S3Client
 from tdpservice.data_files.tasks import reparse_files
+from tdpservice.data_files.util import create_s3_log_file_path
 from tdpservice.log_handler import S3FileHandler
 from tdpservice.parsers.models import DataFileSummary, ParserError
 
@@ -122,10 +123,7 @@ class DataFileAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
         # Remove the 'Logs' fieldset if the file doesn't exist
         datafile = obj
         if datafile:
-            link = (
-                f"{datafile.year}/{datafile.quarter}/"
-                f"{datafile.stt}/{datafile.section}"
-            )
+            link = create_s3_log_file_path(datafile)
             response = S3FileHandler.download_file(key=link)
             if response is not None:
                 return field_sets

--- a/tdrs-backend/tdpservice/data_files/error_reports.py
+++ b/tdrs-backend/tdpservice/data_files/error_reports.py
@@ -10,7 +10,7 @@ from django.db.models import Count, Q
 import xlsxwriter
 
 from tdpservice.data_files.models import DataFile
-from tdpservice.data_files.util import ParserErrorCategoryChoices
+from tdpservice.data_files.parser_error_choices import ParserErrorCategoryChoices
 from tdpservice.parsers.models import ParserError
 
 

--- a/tdrs-backend/tdpservice/data_files/parser_error_choices.py
+++ b/tdrs-backend/tdpservice/data_files/parser_error_choices.py
@@ -1,0 +1,15 @@
+"""Utility functions for DataFile views."""
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class ParserErrorCategoryChoices(models.TextChoices):
+    """Enum of ParserError error_type."""
+
+    PRE_CHECK = "1", _("File pre-check")
+    FIELD_VALUE = "2", _("Record value invalid")
+    VALUE_CONSISTENCY = "3", _("Record value consistency")
+    CASE_CONSISTENCY = "4", _("Case consistency")
+    SECTION_CONSISTENCY = "5", _("Section consistency")
+    HISTORICAL_CONSISTENCY = "6", _("Historical consistency")
+    RECORD_PRE_CHECK = "7", _("Record pre-check")

--- a/tdrs-backend/tdpservice/data_files/views.py
+++ b/tdrs-backend/tdpservice/data_files/views.py
@@ -91,7 +91,8 @@ class DataFileViewSet(ModelViewSet):
 
             logger.info(
                 f"Preparing parse task: User META -> user: {request.user}, stt: {data_file.stt}. "
-                + f"Datafile META -> datafile: {data_file_id}, section: {data_file.section}, "
+                + f"Datafile META -> datafile: {data_file_id}, program type: {data_file.program_type}, "
+                + f"section: {data_file.section}, "
                 + f"quarter {data_file.quarter}, year {data_file.year}."
             )
 

--- a/tdrs-backend/tdpservice/parsers/error_generator.py
+++ b/tdrs-backend/tdpservice/parsers/error_generator.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from django.contrib.contenttypes.models import ContentType
 
-from tdpservice.parsers.models import ParserErrorCategoryChoices
+from tdpservice.data_files.parser_error_choices import ParserErrorCategoryChoices
 
 from .dataclasses import ErrorGeneratorArgs
 from .models import ParserError

--- a/tdrs-backend/tdpservice/parsers/models.py
+++ b/tdrs-backend/tdpservice/parsers/models.py
@@ -10,7 +10,7 @@ from django.db import models
 
 from tdpservice.backends import DataFilesS3Storage
 from tdpservice.data_files.models import DataFile
-from tdpservice.data_files.util import ParserErrorCategoryChoices
+from tdpservice.data_files.parser_error_choices import ParserErrorCategoryChoices
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,9 @@ def get_s3_upload_path(instance, filename):
     """Produce a unique upload path for S3 files for a given STT and Quarter."""
     df = instance.datafile
 
-    file_path = f"data_files/{df.year}/{df.quarter}/{df.stt.id}/{df.section}/"
+    file_path = (
+        f"data_files/{df.year}/{df.quarter}/{df.stt.id}/{df.program_type}/{df.section}/"
+    )
 
     file_name_info = filename
 

--- a/tdrs-backend/tdpservice/parsers/test/test_case_consistency.py
+++ b/tdrs-backend/tdpservice/parsers/test/test_case_consistency.py
@@ -5,9 +5,9 @@ from io import StringIO
 
 import pytest
 
+from tdpservice.data_files.parser_error_choices import ParserErrorCategoryChoices
 from tdpservice.parsers.dataclasses import RawRow
 from tdpservice.parsers.error_generator import ErrorGeneratorFactory, ErrorGeneratorType
-from tdpservice.parsers.models import ParserErrorCategoryChoices
 from tdpservice.parsers.test import factories
 from tdpservice.stts.models import STT
 


### PR DESCRIPTION
## Summary of Changes
- Updated Postgres views to leverage program type for correct file querying and versioning
- Update the `remove_all_old_versions` celery task to leverage program type for correct querying (also cleaned up ugly nested loops)
- Add function to create backwards compatible Parser log file paths 
- Updated all newly parsed datafiles to leverage program type in their s3 path
- Updated error report s3 path to leverage program type

## How to Test
For local testing, to prove what was going on with delete old versions task, follow the steps below:

### Creating the Error State (data loss)
- Checkout release tag `v4.4.0`
- Submit `small_ssp_section1.txt` and `cat_4_edge_case.txt` twice for the same stt on TDP v4.4.0
- You should have 4 datafiles in the DB and a total of 54 records
- Bring docker down but preserve volumes
- Switch to `develop` and start the containers
- Run `remove_all_old_df_versions` management command
- Notice that you only have 8 records in the database now. The expected would have been 27 records.

### Proving the Task Runs Correctly
- Now destroy docker AND docker volumes
- Checkout release tag `v4.4.0`
- Submit `small_ssp_section1.txt` and `cat_4_edge_case.txt` twice for the same stt on TDP v4.4.0
- You should have 4 datafiles in the DB and a total of 54 records
- Bring docker down but preserve volumes
- Switch to `hotfix/program-type-dataloss` and start the containers
- Run `remove_all_old_df_versions` management command
- Notice that you now have the expected 27 records and they are associated with the latest versions of the files

**Merged into HHS:main here**
https://github.com/HHS/TANF-app/pull/619