### PR TITLE
Hotfix/circleci python executor wrong version

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.10.8
         user: root
   machine-executor:
     machine:

--- a/tdrs-backend/Pipfile
+++ b/tdrs-backend/Pipfile
@@ -73,3 +73,6 @@ opentelemetry-instrumentation-requests = "==0.54b0"
 
 [requires]
 python_version = "3.10.8"
+
+[pipenv]
+allow_prereleases = true


### PR DESCRIPTION
## Summary of Changes
- Update docker executor to use the correct version of Python
- Update Pipfile to allow Pipenv to install dependencies that depend on pre-release/beta versions