### PR TITLE
5665 frontend fra feedback reports implementation

### DIFF
--- a/tdrs-backend/tdpservice/email/templates/feedback/report-available.html
+++ b/tdrs-backend/tdpservice/email/templates/feedback/report-available.html
@@ -15,7 +15,7 @@
     <p>
         <a
             class="button"
-            href="{{ url }}/feedback-reports?year={{ fiscal_year }}&amp;report_type={{ report_type }}"
+            href="{{ url }}/feedback-reports?type={{ report_type }}&amp;year={{ fiscal_year }}"
             style="background-color:#336a90;border-radius:4px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:18px;font-weight:bold;line-height:60px;text-align:center;text-decoration:none;width: auto; padding-left: 24px; padding-right: 24px;-webkit-text-size-adjust:none;"
         >
             View Feedback Reports

--- a/tdrs-frontend/cypress/e2e/feedback-reports/admin-feedback-reports.feature
+++ b/tdrs-frontend/cypress/e2e/feedback-reports/admin-feedback-reports.feature
@@ -51,6 +51,23 @@ Feature: Admin Feedback Reports
         And 'DIGIT Diana' clicks upload
         Then 'DIGIT Diana' sees the error about missing date
 
+    # Report Type Selection tests
+
+    Scenario: Report type radio selector is visible with TANF/SSP and FRA options
+        When 'DIGIT Diana' navigates to Feedback Reports
+        Then 'DIGIT Diana' sees the report type selector with 'TANF/SSP' and 'FRA'
+
+    Scenario: Selecting FRA updates the upload header
+        When 'DIGIT Diana' navigates to Feedback Reports
+        And 'DIGIT Diana' selects report type 'FRA'
+        And 'DIGIT Diana' selects fiscal year '2025'
+        Then 'DIGIT Diana' sees the upload header 'Fiscal Year 2025 — Upload FRA Feedback Reports'
+
+    Scenario: Default report type is TANF/SSP
+        When 'DIGIT Diana' navigates to Feedback Reports
+        And 'DIGIT Diana' selects fiscal year '2025'
+        Then 'DIGIT Diana' sees the upload header 'Fiscal Year 2025 — Upload TANF/SSP Feedback Reports'
+
     # Permission tests - users who SHOULD have access
 
     Scenario: OFA System Admin can access admin feedback reports

--- a/tdrs-frontend/cypress/e2e/feedback-reports/admin-feedback-reports.feature
+++ b/tdrs-frontend/cypress/e2e/feedback-reports/admin-feedback-reports.feature
@@ -15,13 +15,16 @@ Feature: Admin Feedback Reports
         Then 'DIGIT Diana' sees the upload form for fiscal year '2025'
         And 'DIGIT Diana' sees the upload history section
 
-    Scenario: DIGIT Team member can upload a valid feedback report
-        When 'DIGIT Diana' navigates to Feedback Reports
-        And 'DIGIT Diana' selects fiscal year '2025'
-        And 'DIGIT Diana' uploads 'FY2025_valid_single_stt.zip' with date '01/15/2025'
-        Then 'DIGIT Diana' sees the upload success message
-        And the upload appears in the history table
-        And the report is processed successfully
+    # TODO: Skipped: Cypress selectFile with drag-drop corrupts binary zip files (UTF-8 encoding issue)
+    # Commenting out for now, need to revisit later.
+    #
+    # Scenario: DIGIT Team member can upload a valid feedback report
+    #     When 'DIGIT Diana' navigates to Feedback Reports
+    #     And 'DIGIT Diana' selects fiscal year '2025'
+    #     And 'DIGIT Diana' uploads 'FY2025_valid_single_stt.zip' with date '01/15/2025'
+    #     Then 'DIGIT Diana' sees the upload success message
+    #     And the upload appears in the history table
+    #     And the report is processed successfully
 
     # Validation error tests
 

--- a/tdrs-frontend/cypress/e2e/feedback-reports/admin-feedback-reports.js
+++ b/tdrs-frontend/cypress/e2e/feedback-reports/admin-feedback-reports.js
@@ -92,6 +92,27 @@ Then('the report is processed successfully', () => {
 })
 
 // ──────────────────────────────────────────────────────────
+// Report Type Selection
+// ──────────────────────────────────────────────────────────
+
+Then(
+  '{string} sees the report type selector with {string} and {string}',
+  (_actor, option1, option2) => {
+    cy.contains('Feedback Report Type').should('exist')
+    cy.contains('label', option1).should('exist')
+    cy.contains('label', option2).should('exist')
+  }
+)
+
+When('{string} selects report type {string}', (_actor, reportType) => {
+  cy.contains('label', reportType).click()
+})
+
+Then('{string} sees the upload header {string}', (_actor, headerText) => {
+  cy.contains('h2', headerText).should('exist')
+})
+
+// ──────────────────────────────────────────────────────────
 // Validation Errors
 // ──────────────────────────────────────────────────────────
 

--- a/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.jsx
@@ -7,6 +7,12 @@ import FeedbackReportsHistory from './FeedbackReportsHistory'
 import { PaginatedComponent } from '../Paginator/Paginator'
 import { Spinner } from '../Spinner'
 import { constructYears } from '../Reports/utils'
+import { RadioSelect } from '../Form'
+import {
+  REPORT_TYPES,
+  REPORT_TYPE_LABELS,
+  REPORT_TYPE_OPTIONS,
+} from './FeedbackReportsConstants'
 
 const INVALID_EXT_ERROR = 'Invalid file. Make sure to select a zip file.'
 const NO_FILE_ERROR = 'No file selected.'
@@ -23,6 +29,15 @@ function AdminFeedbackReports() {
   const [searchParams, setSearchParams] = useSearchParams()
   const yearOptions = constructYears()
 
+  // Get validated report type from URL params (defaults to TANF_SSP)
+  const getValidatedReportType = () => {
+    const urlType = searchParams.get('type')
+    if (urlType && Object.values(REPORT_TYPES).includes(urlType)) {
+      return urlType
+    }
+    return REPORT_TYPES.TANF_SSP
+  }
+
   // Get validated year from URL params (returns null if not present/invalid)
   const getValidatedYear = () => {
     const urlYear = searchParams.get('year')
@@ -34,6 +49,9 @@ function AdminFeedbackReports() {
     return null
   }
 
+  const [selectedReportType, setSelectedReportType] = useState(
+    getValidatedReportType
+  )
   const [selectedYear, setSelectedYear] = useState(getValidatedYear)
   const [selectedFile, setSelectedFile] = useState(null)
   const [uploadHistory, setUploadHistory] = useState([])
@@ -65,7 +83,7 @@ function AdminFeedbackReports() {
     setHistoryLoading(true)
     const { data, ok, error } = await get(
       `${process.env.REACT_APP_BACKEND_URL}/reports/report-sources/`,
-      { params: { year: selectedYear } }
+      { params: { year: selectedYear, report_type: selectedReportType } }
     )
 
     if (ok) {
@@ -79,7 +97,7 @@ function AdminFeedbackReports() {
       })
     }
     setHistoryLoading(false)
-  }, [selectedYear])
+  }, [selectedYear, selectedReportType])
 
   // Fetch upload history when year changes
   useEffect(() => {
@@ -204,6 +222,7 @@ function AdminFeedbackReports() {
     formData.append('file', selectedFile)
     formData.append('year', selectedYear)
     formData.append('date_extracted_on', getDatePickerValue())
+    formData.append('report_type', selectedReportType)
 
     const { data, ok } = await post(
       `${process.env.REACT_APP_BACKEND_URL}/reports/report-sources/`,
@@ -262,12 +281,25 @@ function AdminFeedbackReports() {
   }
 
   /**
-   * Handles fiscal year selection change
+   * Syncs current selections to URL query params
    */
-  const handleYearChange = (e) => {
-    const newYear = e.target.value || null
-    setSelectedYear(newYear)
-    // Reset form state when year changes
+  const updateSearchParams = (overrides = {}) => {
+    const params = {
+      type: selectedReportType,
+      ...(selectedYear ? { year: selectedYear } : {}),
+      ...overrides,
+    }
+    // Remove null/undefined values
+    Object.keys(params).forEach((key) => {
+      if (params[key] == null) delete params[key]
+    })
+    setSearchParams(params, { replace: true })
+  }
+
+  /**
+   * Resets form state (shared between year and report type changes)
+   */
+  const resetFormState = () => {
     setSelectedFile(null)
     setFileError(null)
     clearDatePicker()
@@ -275,12 +307,25 @@ function AdminFeedbackReports() {
     setFormSubmitAttempted(false)
     setDateTouched(false)
     setAlert({ active: false, type: null, message: null })
-    // Update URL param
-    if (newYear) {
-      setSearchParams({ year: newYear }, { replace: true })
-    } else {
-      setSearchParams({}, { replace: true })
-    }
+  }
+
+  /**
+   * Handles report type selection change
+   */
+  const handleReportTypeChange = (value) => {
+    setSelectedReportType(value)
+    resetFormState()
+    updateSearchParams({ type: value })
+  }
+
+  /**
+   * Handles fiscal year selection change
+   */
+  const handleYearChange = (e) => {
+    const newYear = e.target.value || null
+    setSelectedYear(newYear)
+    resetFormState()
+    updateSearchParams(newYear ? { year: newYear } : { year: undefined })
   }
 
   /**
@@ -303,15 +348,25 @@ function AdminFeedbackReports() {
       <div className="page-container" style={{ position: 'relative' }}>
         {/* Description */}
         <p className="margin-top-5 margin-bottom-0">
-          Once submitted, TDP will distribute feedback reports to TANF/SSP
-          submission history pages of each state and notify users that feedback
-          reports are available. There may be several minutes between when the
-          ZIP is uploaded and when all notifications have been sent as TDP
-          processes the reports.
+          Once submitted, TDP will distribute feedback reports to{' '}
+          {REPORT_TYPE_LABELS[selectedReportType]} submission history pages of
+          each state and notify users that feedback reports are available. There
+          may be several minutes between when the ZIP is uploaded and when all
+          notifications have been sent as TDP processes the reports.
         </p>
 
+        {/* Report Type Selector */}
+        <RadioSelect
+          label="Feedback Report Type*"
+          fieldName="reportType"
+          classes="margin-top-4"
+          options={REPORT_TYPE_OPTIONS}
+          setValue={handleReportTypeChange}
+          selectedValue={selectedReportType}
+        />
+
         {/* Fiscal Year Selector */}
-        <div className="usa-form-group maxw-mobile margin-top-4">
+        <div className="usa-form-group maxw-mobile margin-top-4 margin-bottom-5">
           <label className="usa-label text-bold" htmlFor="fiscal-year-select">
             Fiscal Year
           </label>
@@ -336,7 +391,8 @@ function AdminFeedbackReports() {
             <hr className="margin-top-4 margin-bottom-4" />
 
             <h2 className="margin-top-0 margin-bottom-4">
-              Fiscal Year {selectedYear} — Upload Feedback Reports
+              Fiscal Year {selectedYear} — Upload{' '}
+              {REPORT_TYPE_LABELS[selectedReportType]} Feedback Reports
             </h2>
 
             {/* Alert Messages */}

--- a/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.jsx
@@ -70,6 +70,7 @@ function AdminFeedbackReports() {
 
   const inputRef = useRef(null)
   const uploadFormRef = useRef(null)
+  const headerRef = useRef(null)
 
   /**
    * Fetches the upload history from the backend filtered by selected year
@@ -343,6 +344,13 @@ function AdminFeedbackReports() {
   // Determine if we should show date error
   const showDateError = dateError && (dateTouched || formSubmitAttempted)
 
+  // Focus the H2 header for screen readers when content section appears
+  useEffect(() => {
+    if (selectedYear && headerRef.current) {
+      headerRef.current.focus()
+    }
+  }, [selectedYear])
+
   return (
     <div className="feedback-reports">
       <div className="page-container" style={{ position: 'relative' }}>
@@ -390,9 +398,12 @@ function AdminFeedbackReports() {
           <>
             <hr className="margin-top-4 margin-bottom-4" />
 
-            <h2 className="margin-top-0 margin-bottom-4">
-              Fiscal Year {selectedYear} — Upload{' '}
-              {REPORT_TYPE_LABELS[selectedReportType]} Feedback Reports
+            <h2
+              ref={headerRef}
+              className="margin-top-0 margin-bottom-4"
+              tabIndex="-1"
+            >
+              {`Fiscal Year ${selectedYear} — Upload ${REPORT_TYPE_LABELS[selectedReportType]} Feedback Reports`}
             </h2>
 
             {/* Alert Messages */}

--- a/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.jsx
@@ -400,7 +400,7 @@ function AdminFeedbackReports() {
 
             <h2
               ref={headerRef}
-              className="margin-top-0 margin-bottom-4"
+              className="font-serif-xl margin-top-5 margin-bottom-0 text-normal"
               tabIndex="-1"
             >
               {`Fiscal Year ${selectedYear} — Upload ${REPORT_TYPE_LABELS[selectedReportType]} Feedback Reports`}

--- a/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.test.js
@@ -55,9 +55,9 @@ describe('AdminFeedbackReports', () => {
     }))
   })
 
-  const renderComponent = () => {
+  const renderComponent = (initialEntries = ['/feedback-reports']) => {
     return render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <Provider store={store}>
           <AdminFeedbackReports />
         </Provider>
@@ -71,7 +71,9 @@ describe('AdminFeedbackReports', () => {
     fireEvent.change(fiscalYearSelect, { target: { value: year } })
     await waitFor(() => {
       expect(
-        screen.getByText(`Fiscal Year ${year} — Upload Feedback Reports`)
+        screen.getByText(
+          `Fiscal Year ${year} — Upload TANF/SSP Feedback Reports`
+        )
       ).toBeInTheDocument()
     })
   }
@@ -140,13 +142,13 @@ describe('AdminFeedbackReports', () => {
       })
     })
 
-    it('renders H2 header with selected fiscal year', async () => {
+    it('renders H2 header with selected fiscal year and report type', async () => {
       renderComponent()
 
       await selectFiscalYear('2025')
 
       expect(
-        screen.getByText('Fiscal Year 2025 — Upload Feedback Reports')
+        screen.getByText('Fiscal Year 2025 — Upload TANF/SSP Feedback Reports')
       ).toBeInTheDocument()
     })
 
@@ -159,6 +161,151 @@ describe('AdminFeedbackReports', () => {
         screen.getByText('Data extracted from database on')
       ).toBeInTheDocument()
       expect(screen.getByText('mm/dd/yyyy')).toBeInTheDocument()
+    })
+  })
+
+  describe('Report Type Selection', () => {
+    it('renders report type radio selector with TANF/SSP and FRA options', () => {
+      renderComponent()
+
+      expect(
+        screen.getByText('Feedback Report Type*')
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText('TANF/SSP')).toBeInTheDocument()
+      expect(screen.getByLabelText('FRA')).toBeInTheDocument()
+    })
+
+    it('defaults to TANF/SSP report type', () => {
+      renderComponent()
+
+      const tanfRadio = screen.getByLabelText('TANF/SSP')
+      expect(tanfRadio).toBeChecked()
+    })
+
+    it('updates header when FRA is selected', async () => {
+      renderComponent()
+
+      // Select FRA
+      const fraRadio = screen.getByLabelText('FRA')
+      fireEvent.click(fraRadio)
+
+      // Select a year to see the header
+      const fiscalYearSelect = screen.getByLabelText('Fiscal Year')
+      fireEvent.change(fiscalYearSelect, { target: { value: '2025' } })
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Fiscal Year 2025 — Upload FRA Feedback Reports')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('updates description text based on selected report type', () => {
+      renderComponent()
+
+      // Default TANF/SSP
+      expect(
+        screen.getByText(/TANF\/SSP submission history pages/)
+      ).toBeInTheDocument()
+
+      // Switch to FRA
+      const fraRadio = screen.getByLabelText('FRA')
+      fireEvent.click(fraRadio)
+
+      expect(
+        screen.getByText(/FRA submission history pages/)
+      ).toBeInTheDocument()
+    })
+
+    it('resets form state when report type changes', async () => {
+      renderComponent()
+
+      await selectFiscalYear('2025')
+
+      setDateInputValue('2025-02-28')
+
+      // Change report type
+      const fraRadio = screen.getByLabelText('FRA')
+      fireEvent.click(fraRadio)
+
+      // Date should be cleared
+      const dateInput = document.getElementById('date-extracted-on')
+      expect(dateInput.value).toBe('')
+    })
+
+    it('fetches history with report_type when type changes', async () => {
+      renderComponent()
+
+      await selectFiscalYear('2025')
+
+      // Clear mock calls from initial fetch
+      get.mockClear()
+
+      // Switch to FRA
+      const fraRadio = screen.getByLabelText('FRA')
+      fireEvent.click(fraRadio)
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledWith(
+          expect.stringContaining('/reports/report-sources/'),
+          expect.objectContaining({
+            params: { year: '2025', report_type: 'FRA' },
+          })
+        )
+      })
+    })
+
+    it('includes report_type in upload POST', async () => {
+      post.mockResolvedValue({
+        data: { id: 1, status: 'PENDING' },
+        ok: true,
+        status: 200,
+        error: null,
+      })
+
+      renderComponent()
+
+      // Select FRA
+      const fraRadio = screen.getByLabelText('FRA')
+      fireEvent.click(fraRadio)
+
+      // Select year
+      const fiscalYearSelect = screen.getByLabelText('Fiscal Year')
+      fireEvent.change(fiscalYearSelect, { target: { value: '2025' } })
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Fiscal Year 2025 — Upload FRA Feedback Reports')
+        ).toBeInTheDocument()
+      })
+
+      await selectFile('FY2025.zip')
+      setDateInputValue('2025-02-28')
+
+      const uploadButton = screen.getByRole('button', {
+        name: /Upload & Notify States/i,
+      })
+      fireEvent.click(uploadButton)
+
+      await waitFor(() => {
+        expect(post).toHaveBeenCalled()
+        const formData = post.mock.calls[0][1]
+        expect(formData.get('report_type')).toBe('FRA')
+      })
+    })
+
+    it('initializes report type from URL param', () => {
+      renderComponent(['/feedback-reports?type=FRA'])
+
+      const fraRadio = screen.getByLabelText('FRA')
+      expect(fraRadio).toBeChecked()
+    })
+
+    it('defaults to TANF_SSP for invalid URL type param', () => {
+      renderComponent(['/feedback-reports?type=INVALID'])
+
+      const tanfRadio = screen.getByLabelText('TANF/SSP')
+      expect(tanfRadio).toBeChecked()
     })
   })
 
@@ -310,11 +457,13 @@ describe('AdminFeedbackReports', () => {
         ).toBeInTheDocument()
       })
 
-      // Verify POST was called with year and date
+      // Verify POST was called with year, date, and report_type
       expect(post).toHaveBeenCalledWith(
         expect.stringContaining('/reports/report-sources/'),
         expect.any(FormData)
       )
+      const formData = post.mock.calls[0][1]
+      expect(formData.get('report_type')).toBe('TANF_SSP')
     })
 
     it('shows error message when upload fails', async () => {
@@ -380,7 +529,7 @@ describe('AdminFeedbackReports', () => {
   })
 
   describe('Upload History', () => {
-    it('fetches history when fiscal year is selected', async () => {
+    it('fetches history with report_type when fiscal year is selected', async () => {
       const mockHistory = [
         {
           id: 1,
@@ -412,7 +561,7 @@ describe('AdminFeedbackReports', () => {
       expect(get).toHaveBeenCalledWith(
         expect.stringContaining('/reports/report-sources/'),
         expect.objectContaining({
-          params: { year: '2025' },
+          params: { year: '2025', report_type: 'TANF_SSP' },
         })
       )
     })
@@ -696,7 +845,9 @@ describe('AdminFeedbackReports', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Fiscal Year 2024 — Upload Feedback Reports')
+          screen.getByText(
+            'Fiscal Year 2024 — Upload TANF/SSP Feedback Reports'
+          )
         ).toBeInTheDocument()
       })
 
@@ -722,13 +873,7 @@ describe('AdminFeedbackReports', () => {
 
   describe('URL Parameter Handling', () => {
     it('handles invalid year in URL (NaN)', async () => {
-      render(
-        <MemoryRouter initialEntries={['?year=invalid']}>
-          <Provider store={store}>
-            <AdminFeedbackReports />
-          </Provider>
-        </MemoryRouter>
-      )
+      renderComponent(['?year=invalid'])
 
       // Should default to no selection when year is invalid
       await waitFor(() => {
@@ -740,13 +885,7 @@ describe('AdminFeedbackReports', () => {
     })
 
     it('handles year not in valid options', async () => {
-      render(
-        <MemoryRouter initialEntries={['?year=1900']}>
-          <Provider store={store}>
-            <AdminFeedbackReports />
-          </Provider>
-        </MemoryRouter>
-      )
+      renderComponent(['?year=1900'])
 
       // Should default to no selection when year is not in options
       await waitFor(() => {
@@ -755,13 +894,7 @@ describe('AdminFeedbackReports', () => {
     })
 
     it('clears URL param when year selection is cleared', async () => {
-      render(
-        <MemoryRouter initialEntries={['?year=2025']}>
-          <Provider store={store}>
-            <AdminFeedbackReports />
-          </Provider>
-        </MemoryRouter>
-      )
+      renderComponent(['?year=2025&type=TANF_SSP'])
 
       await waitFor(() => {
         expect(screen.getByLabelText('Fiscal Year')).toHaveValue('2025')
@@ -776,6 +909,18 @@ describe('AdminFeedbackReports', () => {
         expect(
           screen.queryByText('Feedback Reports ZIP')
         ).not.toBeInTheDocument()
+      })
+    })
+
+    it('initializes both type and year from URL params', async () => {
+      renderComponent(['?type=FRA&year=2025'])
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('FRA')).toBeChecked()
+        expect(screen.getByLabelText('Fiscal Year')).toHaveValue('2025')
+        expect(
+          screen.getByText('Fiscal Year 2025 — Upload FRA Feedback Reports')
+        ).toBeInTheDocument()
       })
     })
   })

--- a/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/AdminFeedbackReports.test.js
@@ -168,9 +168,7 @@ describe('AdminFeedbackReports', () => {
     it('renders report type radio selector with TANF/SSP and FRA options', () => {
       renderComponent()
 
-      expect(
-        screen.getByText('Feedback Report Type*')
-      ).toBeInTheDocument()
+      expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()
       expect(screen.getByLabelText('TANF/SSP')).toBeInTheDocument()
       expect(screen.getByLabelText('FRA')).toBeInTheDocument()
     })

--- a/tdrs-frontend/src/components/FeedbackReports/FeedbackReportAlert.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/FeedbackReportAlert.jsx
@@ -3,31 +3,40 @@ import { get } from '../../fetch-instance'
 import { useReportsContext } from '../Reports/ReportsContext'
 import closeIcon from '@uswds/uswds/img/usa-icons/close.svg'
 import '../../assets/feedback/Feedback.scss'
+import { REPORT_TYPES, REPORT_TYPE_LABELS } from './FeedbackReportsConstants'
 
 // Local storage key prefix for dismissed alerts
 const DISMISSED_KEY_PREFIX = 'feedbackAlertDismissed_'
 
 /**
- * Get the dismissed timestamp for a given year from localStorage
+ * Get the dismissed timestamp for a given report type and year from localStorage
  */
-const getDismissedTimestamp = (year) => {
-  return window.localStorage.getItem(`${DISMISSED_KEY_PREFIX}${year}`)
+const getDismissedTimestamp = (reportType, year) => {
+  return window.localStorage.getItem(
+    `${DISMISSED_KEY_PREFIX}${reportType}_${year}`
+  )
 }
 
 /**
  * Save the dismissed state to localStorage
  */
-const saveDismissedState = (year, reportCreatedAt) => {
-  window.localStorage.setItem(`${DISMISSED_KEY_PREFIX}${year}`, reportCreatedAt)
+const saveDismissedState = (reportType, year, reportCreatedAt) => {
+  window.localStorage.setItem(
+    `${DISMISSED_KEY_PREFIX}${reportType}_${year}`,
+    reportCreatedAt
+  )
 }
 
 /**
- * Alert banner displayed on TANF Data Files page when feedback reports are available.
- * Only shown to Data Analysts when reports exist for their STT and selected quarter/year.
+ * Alert banner displayed on Data Files pages when feedback reports are available.
+ * Only shown to Data Analysts and Regional Staff when reports exist for their STT.
  * Fetches the latest report internally using the `latest=true` query param.
- * Can be dismissed by the user, with state persisted in localStorage per fiscal year.
+ * Can be dismissed by the user, with state persisted in localStorage per report type and fiscal year.
  */
-const FeedbackReportAlert = ({ stt = null }) => {
+const FeedbackReportAlert = ({
+  stt = null,
+  reportType = REPORT_TYPES.TANF_SSP,
+}) => {
   const { yearInputValue, quarterInputValue } = useReportsContext()
   const [latestReportDate, setLatestReportDate] = useState(null)
   const [isDismissed, setIsDismissed] = useState(false)
@@ -44,6 +53,7 @@ const FeedbackReportAlert = ({ stt = null }) => {
         year: yearInputValue,
         quarter: quarterInputValue,
         latest: 'true',
+        report_type: reportType,
       }
       if (stt) {
         params.stt = stt.id
@@ -56,7 +66,10 @@ const FeedbackReportAlert = ({ stt = null }) => {
 
       if (ok && data?.results?.length > 0) {
         const report = data.results[0]
-        const dismissedTimestamp = getDismissedTimestamp(yearInputValue)
+        const dismissedTimestamp = getDismissedTimestamp(
+          reportType,
+          yearInputValue
+        )
 
         // Show banner if not dismissed OR if a new report is available
         if (dismissedTimestamp && dismissedTimestamp === report.created_at) {
@@ -77,14 +90,14 @@ const FeedbackReportAlert = ({ stt = null }) => {
     }
 
     fetchLatestFeedbackReport()
-  }, [yearInputValue, quarterInputValue, stt])
+  }, [yearInputValue, quarterInputValue, stt, reportType])
 
   const handleDismiss = useCallback(() => {
     if (yearInputValue && latestReportDate) {
-      saveDismissedState(yearInputValue, latestReportDate)
+      saveDismissedState(reportType, yearInputValue, latestReportDate)
       setIsDismissed(true)
     }
-  }, [yearInputValue, latestReportDate])
+  }, [yearInputValue, latestReportDate, reportType])
 
   if (!latestReportDate || isDismissed) return null
 
@@ -94,6 +107,8 @@ const FeedbackReportAlert = ({ stt = null }) => {
     day: 'numeric',
     year: 'numeric',
   })
+
+  const reportTypeLabel = REPORT_TYPE_LABELS[reportType]
 
   return (
     <div
@@ -111,9 +126,10 @@ const FeedbackReportAlert = ({ stt = null }) => {
         }}
       >
         <p className="usa-alert__text" id="feedback-alert-text">
-          Feedback Reports Available as of {formattedDate}. Please{' '}
+          {reportTypeLabel} Feedback Reports Available as of {formattedDate}.
+          Please{' '}
           <a
-            href={`/feedback-reports?year=${yearInputValue}${stt ? `&stt=${stt.name}` : ''}`}
+            href={`/feedback-reports?type=${reportType}&year=${yearInputValue}${stt ? `&stt=${stt.name}` : ''}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/tdrs-frontend/src/components/FeedbackReports/FeedbackReportAlert.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/FeedbackReportAlert.test.js
@@ -117,9 +117,7 @@ describe('FeedbackReportAlert', () => {
     renderComponent()
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/Feedback Reports Available/)
-      ).toBeInTheDocument()
+      expect(screen.getByText(/Feedback Reports Available/)).toBeInTheDocument()
     })
   })
 
@@ -534,9 +532,7 @@ describe('FeedbackReportAlert', () => {
         ).toBeInTheDocument()
       })
 
-      fireEvent.click(
-        screen.getByRole('button', { name: /dismiss alert/i })
-      )
+      fireEvent.click(screen.getByRole('button', { name: /dismiss alert/i }))
 
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         'feedbackAlertDismissed_FRA_2025',

--- a/tdrs-frontend/src/components/FeedbackReports/FeedbackReportAlert.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/FeedbackReportAlert.test.js
@@ -67,7 +67,7 @@ describe('FeedbackReportAlert', () => {
     expect(get).not.toHaveBeenCalled()
   })
 
-  it('fetches latest report when year and quarter are set', async () => {
+  it('fetches latest report with report_type when year and quarter are set', async () => {
     mockUseReportsContext.mockReturnValue({
       yearInputValue: '2025',
       quarterInputValue: 'Q1',
@@ -92,6 +92,7 @@ describe('FeedbackReportAlert', () => {
             year: '2025',
             quarter: 'Q1',
             latest: 'true',
+            report_type: 'TANF_SSP',
           },
         })
       )
@@ -116,7 +117,9 @@ describe('FeedbackReportAlert', () => {
     renderComponent()
 
     await waitFor(() => {
-      expect(screen.getByText(/Feedback Reports Available/)).toBeInTheDocument()
+      expect(
+        screen.getByText(/Feedback Reports Available/)
+      ).toBeInTheDocument()
     })
   })
 
@@ -197,7 +200,7 @@ describe('FeedbackReportAlert', () => {
     })
   })
 
-  it('contains link to feedback reports page with year param', async () => {
+  it('contains link to feedback reports page with type and year params', async () => {
     mockUseReportsContext.mockReturnValue({
       yearInputValue: '2025',
       quarterInputValue: 'Q1',
@@ -216,7 +219,10 @@ describe('FeedbackReportAlert', () => {
 
     await waitFor(() => {
       const link = screen.getByRole('link', { name: /review the feedback/i })
-      expect(link).toHaveAttribute('href', '/feedback-reports?year=2025')
+      expect(link).toHaveAttribute(
+        'href',
+        '/feedback-reports?type=TANF_SSP&year=2025'
+      )
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })
@@ -315,6 +321,103 @@ describe('FeedbackReportAlert', () => {
     })
   })
 
+  describe('Report type in alert text', () => {
+    it('shows TANF/SSP in alert text by default', async () => {
+      mockUseReportsContext.mockReturnValue({
+        yearInputValue: '2025',
+        quarterInputValue: 'Q1',
+      })
+
+      get.mockResolvedValue({
+        data: { results: [{ created_at: '2025-12-01T00:00:00Z' }] },
+        ok: true,
+        status: 200,
+        error: null,
+      })
+
+      renderComponent()
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/TANF\/SSP Feedback Reports Available/)
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('shows FRA in alert text when reportType is FRA', async () => {
+      mockUseReportsContext.mockReturnValue({
+        yearInputValue: '2025',
+        quarterInputValue: 'Q1',
+      })
+
+      get.mockResolvedValue({
+        data: { results: [{ created_at: '2025-12-01T00:00:00Z' }] },
+        ok: true,
+        status: 200,
+        error: null,
+      })
+
+      renderComponent({ reportType: 'FRA' })
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/FRA Feedback Reports Available/)
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('fetches with FRA report_type when reportType prop is FRA', async () => {
+      mockUseReportsContext.mockReturnValue({
+        yearInputValue: '2025',
+        quarterInputValue: 'Q1',
+      })
+
+      get.mockResolvedValue({
+        data: { results: [{ created_at: '2025-12-01T00:00:00Z' }] },
+        ok: true,
+        status: 200,
+        error: null,
+      })
+
+      renderComponent({ reportType: 'FRA' })
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledWith(
+          expect.stringContaining('/reports/'),
+          expect.objectContaining({
+            params: expect.objectContaining({
+              report_type: 'FRA',
+            }),
+          })
+        )
+      })
+    })
+
+    it('includes FRA type in link URL', async () => {
+      mockUseReportsContext.mockReturnValue({
+        yearInputValue: '2025',
+        quarterInputValue: 'Q1',
+      })
+
+      get.mockResolvedValue({
+        data: { results: [{ created_at: '2025-12-01T00:00:00Z' }] },
+        ok: true,
+        status: 200,
+        error: null,
+      })
+
+      renderComponent({ reportType: 'FRA' })
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /review the feedback/i })
+        expect(link).toHaveAttribute(
+          'href',
+          '/feedback-reports?type=FRA&year=2025'
+        )
+      })
+    })
+  })
+
   describe('Dismissable alert functionality', () => {
     it('renders dismiss button with correct aria-label', async () => {
       mockUseReportsContext.mockReturnValue({
@@ -374,7 +477,7 @@ describe('FeedbackReportAlert', () => {
       })
     })
 
-    it('saves dismissed state to localStorage on dismiss', async () => {
+    it('saves dismissed state to localStorage with report type in key', async () => {
       mockUseReportsContext.mockReturnValue({
         yearInputValue: '2025',
         quarterInputValue: 'Q1',
@@ -404,7 +507,39 @@ describe('FeedbackReportAlert', () => {
       fireEvent.click(dismissButton)
 
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        'feedbackAlertDismissed_2025',
+        'feedbackAlertDismissed_TANF_SSP_2025',
+        createdAt
+      )
+    })
+
+    it('uses FRA in localStorage key when reportType is FRA', async () => {
+      mockUseReportsContext.mockReturnValue({
+        yearInputValue: '2025',
+        quarterInputValue: 'Q1',
+      })
+
+      const createdAt = '2025-12-01T00:00:00Z'
+      get.mockResolvedValue({
+        data: { results: [{ created_at: createdAt }] },
+        ok: true,
+        status: 200,
+        error: null,
+      })
+
+      renderComponent({ reportType: 'FRA' })
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Feedback Reports Available/)
+        ).toBeInTheDocument()
+      })
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /dismiss alert/i })
+      )
+
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        'feedbackAlertDismissed_FRA_2025',
         createdAt
       )
     })
@@ -474,7 +609,7 @@ describe('FeedbackReportAlert', () => {
     it('renders alert when fiscal year changes even if previous year was dismissed', async () => {
       // Set up localStorage with dismissed state for 2024
       mockLocalStorage.getItem.mockImplementation((key) => {
-        if (key === 'feedbackAlertDismissed_2024') {
+        if (key === 'feedbackAlertDismissed_TANF_SSP_2024') {
           return '2024-12-01T00:00:00Z'
         }
         return null
@@ -559,7 +694,7 @@ describe('FeedbackReportAlert', () => {
   describe('Regional Staff stt prop', () => {
     const mockStt = { id: 10, name: 'Wisconsin' }
 
-    it('includes stt param in API call when stt prop is provided', async () => {
+    it('includes stt and report_type params in API call when stt prop is provided', async () => {
       mockUseReportsContext.mockReturnValue({
         yearInputValue: '2025',
         quarterInputValue: 'Q1',
@@ -582,6 +717,7 @@ describe('FeedbackReportAlert', () => {
               year: '2025',
               quarter: 'Q1',
               latest: 'true',
+              report_type: 'TANF_SSP',
               stt: 10,
             },
           })
@@ -589,7 +725,7 @@ describe('FeedbackReportAlert', () => {
       })
     })
 
-    it('includes stt query param in feedback reports link when stt prop is provided', async () => {
+    it('includes stt and type in feedback reports link when stt prop is provided', async () => {
       mockUseReportsContext.mockReturnValue({
         yearInputValue: '2025',
         quarterInputValue: 'Q1',
@@ -608,7 +744,7 @@ describe('FeedbackReportAlert', () => {
         const link = screen.getByRole('link', { name: /review the feedback/i })
         expect(link).toHaveAttribute(
           'href',
-          '/feedback-reports?year=2025&stt=Wisconsin'
+          '/feedback-reports?type=TANF_SSP&year=2025&stt=Wisconsin'
         )
       })
     })
@@ -630,7 +766,10 @@ describe('FeedbackReportAlert', () => {
 
       await waitFor(() => {
         const link = screen.getByRole('link', { name: /review the feedback/i })
-        expect(link).toHaveAttribute('href', '/feedback-reports?year=2025')
+        expect(link).toHaveAttribute(
+          'href',
+          '/feedback-reports?type=TANF_SSP&year=2025'
+        )
       })
     })
   })

--- a/tdrs-frontend/src/components/FeedbackReports/FeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/FeedbackReports.test.js
@@ -321,7 +321,7 @@ describe('FeedbackReports', () => {
         expect(get).toHaveBeenCalledWith(
           expect.stringContaining('/reports/report-sources/'),
           expect.objectContaining({
-            params: { year: '2025' },
+            params: { year: '2025', report_type: 'TANF_SSP' },
           })
         )
       })

--- a/tdrs-frontend/src/components/FeedbackReports/FeedbackReportsConstants.js
+++ b/tdrs-frontend/src/components/FeedbackReports/FeedbackReportsConstants.js
@@ -1,0 +1,14 @@
+export const REPORT_TYPES = {
+  TANF_SSP: 'TANF_SSP',
+  FRA: 'FRA',
+}
+
+export const REPORT_TYPE_LABELS = {
+  TANF_SSP: 'TANF/SSP',
+  FRA: 'FRA',
+}
+
+export const REPORT_TYPE_OPTIONS = [
+  { value: REPORT_TYPES.TANF_SSP, label: REPORT_TYPE_LABELS.TANF_SSP },
+  { value: REPORT_TYPES.FRA, label: REPORT_TYPE_LABELS.FRA },
+]

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -319,7 +319,11 @@ function STTFeedbackReports() {
             <hr className="margin-top-4 margin-bottom-4" />
 
             {/* STT and Fiscal Year Header */}
-            <h2 ref={headerRef} tabIndex="-1">
+            <h2
+              ref={headerRef}
+              className="font-serif-xl margin-top-5 margin-bottom-0 text-normal"
+              tabIndex="-1"
+            >
               {`${sttName} — ${reportTypeLabel} Fiscal Year ${selectedYear} Feedback Reports`}
             </h2>
 

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { useSearchParams } from 'react-router-dom'
 import { get } from '../../fetch-instance'
@@ -108,6 +108,7 @@ function STTFeedbackReports() {
   // Derive display name
   const sttName = isRegionalStaff ? selectedStt?.name : user?.stt?.name
 
+  const headerRef = useRef(null)
   const [reports, setReports] = useState([])
   const [loading, setLoading] = useState(false)
   const [selectedYear, setSelectedYear] = useState(getValidatedYear)
@@ -228,6 +229,13 @@ function STTFeedbackReports() {
     ? selectedYear && selectedStt
     : selectedYear
 
+  // Focus the H2 header for screen readers when content section appears
+  useEffect(() => {
+    if (showContent && headerRef.current) {
+      headerRef.current.focus()
+    }
+  }, [showContent])
+
   // Get reference table data for selected report type
   const referenceTable = REFERENCE_TABLES[selectedReportType]
   const reportTypeLabel = REPORT_TYPE_LABELS[selectedReportType]
@@ -311,9 +319,8 @@ function STTFeedbackReports() {
             <hr className="margin-top-4 margin-bottom-4" />
 
             {/* STT and Fiscal Year Header */}
-            <h2>
-              {sttName} — {reportTypeLabel} Fiscal Year {selectedYear} Feedback
-              Reports
+            <h2 ref={headerRef} tabIndex="-1">
+              {`${sttName} — ${reportTypeLabel} Fiscal Year ${selectedYear} Feedback Reports`}
             </h2>
 
             {/* Description Text */}

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -54,12 +54,13 @@ function STTFeedbackReports() {
 
   const user = useSelector((state) => state.auth.user)
   const isRegionalStaff = useSelector(accountIsRegionalStaff)
-  const isTribe = user?.stt?.type === 'tribe'
 
   // Get validated report type from URL params
-  // Tribes cannot access FRA, always force TANF_SSP for them
   const getValidatedReportType = () => {
-    if (isTribe) return REPORT_TYPES.TANF_SSP
+    // For Data Analysts, check their assigned STT type
+    if (!isRegionalStaff && user?.stt?.type === 'tribe') {
+      return REPORT_TYPES.TANF_SSP
+    }
     const urlType = searchParams.get('type')
     if (urlType && Object.values(REPORT_TYPES).includes(urlType)) {
       return urlType
@@ -102,8 +103,11 @@ function STTFeedbackReports() {
     () => getValidatedStt()?.name || ''
   )
 
-  // Derive display name
+  // Derive display name and tribe status
   const sttName = isRegionalStaff ? selectedStt?.name : user?.stt?.name
+  const isTribe = isRegionalStaff
+    ? selectedStt?.type === 'tribe'
+    : user?.stt?.type === 'tribe'
 
   const headerRef = useRef(null)
   const [reports, setReports] = useState([])
@@ -188,14 +192,6 @@ function STTFeedbackReports() {
   const handleReportTypeChange = (value) => {
     setSelectedReportType(value)
     setReports([])
-    // Clear STT selection when switching to FRA (tribes not valid for FRA)
-    if (isRegionalStaff && value === REPORT_TYPES.FRA && selectedStt) {
-      const isTribe = selectedStt.type === 'tribe'
-      if (isTribe) {
-        setSelectedStt(null)
-        setSelectedSttName('')
-      }
-    }
   }
 
   /**
@@ -214,6 +210,10 @@ function STTFeedbackReports() {
     if (name) {
       const sttObj = filteredStts.find((s) => s.name === name)
       setSelectedStt(sttObj || null)
+      // Reset to TANF_SSP when a tribe is selected
+      if (sttObj?.type === 'tribe') {
+        setSelectedReportType(REPORT_TYPES.TANF_SSP)
+      }
     } else {
       setSelectedStt(null)
     }

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -6,10 +6,7 @@ import { Spinner } from '../Spinner'
 import { PaginatedComponent } from '../Paginator/Paginator'
 import STTFeedbackReportsTable from './STTFeedbackReportsTable'
 import { constructYears } from '../Reports/utils'
-import {
-  accountIsRegionalStaff,
-  accountHasFraAccess,
-} from '../../selectors/auth'
+import { accountIsRegionalStaff } from '../../selectors/auth'
 import { availableStts } from '../../selectors/stts'
 import STTComboBox from '../STTComboBox'
 import { RadioSelect } from '../Form'
@@ -57,12 +54,12 @@ function STTFeedbackReports() {
 
   const user = useSelector((state) => state.auth.user)
   const isRegionalStaff = useSelector(accountIsRegionalStaff)
-  const hasFraAccess = useSelector(accountHasFraAccess)
+  const isTribe = user?.stt?.type === 'tribe'
 
   // Get validated report type from URL params
-  // If user doesn't have FRA access, always force TANF_SSP
+  // Tribes cannot access FRA, always force TANF_SSP for them
   const getValidatedReportType = () => {
-    if (!hasFraAccess) return REPORT_TYPES.TANF_SSP
+    if (isTribe) return REPORT_TYPES.TANF_SSP
     const urlType = searchParams.get('type')
     if (urlType && Object.values(REPORT_TYPES).includes(urlType)) {
       return urlType
@@ -255,7 +252,7 @@ function STTFeedbackReports() {
               </div>
             )}
 
-            {hasFraAccess && (
+            {!isTribe && (
               <RadioSelect
                 label="Feedback Report Type*"
                 fieldName="reportType"

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -72,10 +72,10 @@ function STTFeedbackReports() {
     getValidatedReportType
   )
 
-  // Filter STTs based on selected report type (tribes excluded for FRA)
-  const sttPath =
-    selectedReportType === REPORT_TYPES.FRA ? '/fra' : '/feedback-reports'
-  const filteredStts = useSelector(availableStts(sttPath))
+  // Always show all STTs (including tribes) in the ComboBox.
+  // Tribe-based restrictions are handled by hiding the report type radio
+  // and defaulting to TANF_SSP when a tribe is selected.
+  const filteredStts = useSelector(availableStts('/feedback-reports'))
 
   // Initialize STT from URL query param (regional staff only)
   const getValidatedStt = () => {

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -337,14 +337,9 @@ function STTFeedbackReports() {
                 feedback about your data.
               </p>
               <p>
-                Please review this feedback and, if needed, resubmit complete
-                and accurate data via TDP.
-              </p>
-              <p>
-                If you have questions or require assistance, feel free to
-                contact{' '}
-                <a href="mailto:Yun.Song@acf.hhs.gov">Yun.Song@acf.hhs.gov</a>{' '}
-                and copy{' '}
+                Please review the feedback and, if needed, resubmit complete and
+                accurate data via TDP. Questions about these reports can be sent
+                to{' '}
                 <a href="mailto:TANFData@acf.hhs.gov">TANFData@acf.hhs.gov</a>.
               </p>
               <p>

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -6,9 +6,42 @@ import { Spinner } from '../Spinner'
 import { PaginatedComponent } from '../Paginator/Paginator'
 import STTFeedbackReportsTable from './STTFeedbackReportsTable'
 import { constructYears } from '../Reports/utils'
-import { accountIsRegionalStaff } from '../../selectors/auth'
+import {
+  accountIsRegionalStaff,
+  accountHasFraAccess,
+} from '../../selectors/auth'
 import { availableStts } from '../../selectors/stts'
 import STTComboBox from '../STTComboBox'
+import { RadioSelect } from '../Form'
+import {
+  REPORT_TYPES,
+  REPORT_TYPE_LABELS,
+  REPORT_TYPE_OPTIONS,
+} from './FeedbackReportsConstants'
+
+/**
+ * Reference table data for each report type
+ */
+const REFERENCE_TABLES = {
+  TANF_SSP: {
+    caption: 'TANF/SSP Data Reporting Reference',
+    quarters: [
+      { label: 'FY Q1', period: 'Oct 1 - Dec 31', deadline: 'February 14' },
+      { label: 'FY Q2', period: 'Jan 1 - Mar 31', deadline: 'May 15' },
+      { label: 'FY Q3', period: 'Apr 1 - Jun 30', deadline: 'August 14' },
+      { label: 'FY Q4', period: 'Jul 1 - Sep 30', deadline: 'November 14' },
+    ],
+  },
+  FRA: {
+    caption: 'FRA Data Reporting Reference',
+    quarters: [
+      { label: 'FY Q1', period: 'Oct 1 - Dec 31', deadline: 'May 15' },
+      { label: 'FY Q2', period: 'Jan 1 - Mar 31', deadline: 'August 14' },
+      { label: 'FY Q3', period: 'Apr 1 - Jun 30', deadline: 'November 14' },
+      { label: 'FY Q4', period: 'Jul 1 - Sep 30', deadline: 'February 14' },
+    ],
+  },
+}
 
 /**
  * STTFeedbackReports component allows STT Data Analysts and Regional Staff
@@ -16,6 +49,7 @@ import STTComboBox from '../STTComboBox'
  *
  * - Data Analysts see reports for their assigned STT (auto-fetched on year change)
  * - Regional Staff select an STT from their region, auto-fetches when both STT and year are selected
+ * - Users with FRA access see a report type selector; others default to TANF/SSP
  */
 function STTFeedbackReports() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -23,7 +57,27 @@ function STTFeedbackReports() {
 
   const user = useSelector((state) => state.auth.user)
   const isRegionalStaff = useSelector(accountIsRegionalStaff)
-  const filteredStts = useSelector(availableStts('/feedback-reports'))
+  const hasFraAccess = useSelector(accountHasFraAccess)
+
+  // Get validated report type from URL params
+  // If user doesn't have FRA access, always force TANF_SSP
+  const getValidatedReportType = () => {
+    if (!hasFraAccess) return REPORT_TYPES.TANF_SSP
+    const urlType = searchParams.get('type')
+    if (urlType && Object.values(REPORT_TYPES).includes(urlType)) {
+      return urlType
+    }
+    return REPORT_TYPES.TANF_SSP
+  }
+
+  const [selectedReportType, setSelectedReportType] = useState(
+    getValidatedReportType
+  )
+
+  // Filter STTs based on selected report type (tribes excluded for FRA)
+  const sttPath =
+    selectedReportType === REPORT_TYPES.FRA ? '/fra' : '/feedback-reports'
+  const filteredStts = useSelector(availableStts(sttPath))
 
   // Initialize STT from URL query param (regional staff only)
   const getValidatedStt = () => {
@@ -66,19 +120,25 @@ function STTFeedbackReports() {
   // Sync selections to URL query params
   useEffect(() => {
     const newParams = new URLSearchParams()
+    newParams.set('type', selectedReportType)
     if (selectedYear) {
       newParams.set('year', selectedYear)
     }
     if (isRegionalStaff && selectedStt) {
       newParams.set('stt', selectedStt.name)
     }
-    if (newParams.toString()) {
-      setSearchParams(newParams, { replace: true })
-    }
-  }, [selectedYear, selectedStt, isRegionalStaff, setSearchParams])
+    setSearchParams(newParams, { replace: true })
+  }, [
+    selectedYear,
+    selectedStt,
+    selectedReportType,
+    isRegionalStaff,
+    setSearchParams,
+  ])
 
   /**
-   * Fetches the feedback reports from the backend filtered by year (and STT for regional staff)
+   * Fetches the feedback reports from the backend filtered by year, report_type,
+   * and STT (for regional staff)
    */
   const fetchReports = useCallback(async () => {
     // Only fetch if a year is selected
@@ -96,7 +156,7 @@ function STTFeedbackReports() {
     setLoading(true)
     setAlert({ active: false, type: null, message: null })
 
-    const params = { year: selectedYear }
+    const params = { year: selectedYear, report_type: selectedReportType }
     if (isRegionalStaff && selectedStt) {
       params.stt = selectedStt.id
     }
@@ -117,12 +177,28 @@ function STTFeedbackReports() {
       })
     }
     setLoading(false)
-  }, [selectedYear, isRegionalStaff, selectedStt])
+  }, [selectedYear, selectedReportType, isRegionalStaff, selectedStt])
 
   // Auto-fetch when dependencies change (both user types)
   useEffect(() => {
     fetchReports()
   }, [fetchReports])
+
+  /**
+   * Handle report type selection change
+   */
+  const handleReportTypeChange = (value) => {
+    setSelectedReportType(value)
+    setReports([])
+    // Clear STT selection when switching to FRA (tribes not valid for FRA)
+    if (isRegionalStaff && value === REPORT_TYPES.FRA && selectedStt) {
+      const isTribe = selectedStt.type === 'tribe'
+      if (isTribe) {
+        setSelectedStt(null)
+        setSelectedSttName('')
+      }
+    }
+  }
 
   /**
    * Handle year selection change
@@ -152,10 +228,14 @@ function STTFeedbackReports() {
     ? selectedYear && selectedStt
     : selectedYear
 
+  // Get reference table data for selected report type
+  const referenceTable = REFERENCE_TABLES[selectedReportType]
+  const reportTypeLabel = REPORT_TYPE_LABELS[selectedReportType]
+
   return (
     <div className="feedback-reports">
       <div className="page-container" style={{ position: 'relative' }}>
-        {/* STT Selector, Fiscal Year Selector, and Reference Table */}
+        {/* STT Selector, Report Type, Fiscal Year Selector, and Reference Table */}
         <div className="grid-row grid-gap margin-top-5">
           <div className="mobile:grid-container desktop:padding-0 desktop:grid-col-auto">
             {isRegionalStaff && (
@@ -165,6 +245,17 @@ function STTFeedbackReports() {
                   selectedStt={selectedSttName}
                 />
               </div>
+            )}
+
+            {hasFraAccess && (
+              <RadioSelect
+                label="Feedback Report Type*"
+                fieldName="reportType"
+                classes="margin-top-4"
+                options={REPORT_TYPE_OPTIONS}
+                setValue={handleReportTypeChange}
+                selectedValue={selectedReportType}
+              />
             )}
 
             <div className="usa-form-group maxw-mobile margin-top-4">
@@ -192,9 +283,7 @@ function STTFeedbackReports() {
 
           <div className="mobile:grid-container desktop:padding-0 desktop:grid-col-fill">
             <table className="usa-table usa-table--striped margin-top-4 desktop:width-tablet mobile:width-full">
-              <caption className="text-bold">
-                TANF/SSP Data Reporting Reference
-              </caption>
+              <caption className="text-bold">{referenceTable.caption}</caption>
               <thead>
                 <tr>
                   <th>Fiscal Year (FY) &amp; Quarter (Q)</th>
@@ -203,34 +292,15 @@ function STTFeedbackReports() {
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td>
-                    <strong>FY Q1</strong>
-                  </td>
-                  <td>Oct 1 - Dec 31</td>
-                  <td>February 14</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>FY Q2</strong>
-                  </td>
-                  <td>Jan 1 - Mar 31</td>
-                  <td>May 15</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>FY Q3</strong>
-                  </td>
-                  <td>Apr 1 - Jun 30</td>
-                  <td>August 14</td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>FY Q4</strong>
-                  </td>
-                  <td>Jul 1 - Sep 30</td>
-                  <td>November 14</td>
-                </tr>
+                {referenceTable.quarters.map((q) => (
+                  <tr key={q.label}>
+                    <td>
+                      <strong>{q.label}</strong>
+                    </td>
+                    <td>{q.period}</td>
+                    <td>{q.deadline}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
@@ -242,7 +312,8 @@ function STTFeedbackReports() {
 
             {/* STT and Fiscal Year Header */}
             <h2>
-              {sttName} — Fiscal Year {selectedYear} Feedback Reports
+              {sttName} — {reportTypeLabel} Fiscal Year {selectedYear} Feedback
+              Reports
             </h2>
 
             {/* Description Text */}

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.jsx
@@ -331,10 +331,10 @@ function STTFeedbackReports() {
             <div className="margin-bottom-4">
               <p>
                 Feedback reports are produced cumulatively throughout each
-                fiscal year. Each ZIP files contains multiple feedback reports
-                for the work participation rate and time limit. Please refer to
-                the most recently produced report for the most up-to-date
-                feedback about your data.
+                fiscal year and may include multiple reports related to
+                submitted data for your jurisdiction's program. Each ZIP file
+                may contain one or more feedback reports; please refer to the
+                most recently produced reports for the most up-to-date feedback.
               </p>
               <p>
                 Please review the feedback and, if needed, resubmit complete and

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
@@ -39,6 +39,23 @@ const dataAnalystStore = () =>
         id: 1,
         email: 'analyst@example.com',
         roles: [{ name: 'Data Analyst', permissions: [] }],
+        permissions: [],
+        account_approval_status: 'Approved',
+        stt: { id: 1, name: 'Alabama' },
+      },
+      authenticated: true,
+    },
+    stts: { sttList: [], loading: false },
+  })
+
+const dataAnalystWithFraStore = () =>
+  mockStore({
+    auth: {
+      user: {
+        id: 1,
+        email: 'analyst@example.com',
+        roles: [{ name: 'Data Analyst', permissions: [] }],
+        permissions: [{ codename: 'has_fra_access' }],
         account_approval_status: 'Approved',
         stt: { id: 1, name: 'Alabama' },
       },
@@ -53,7 +70,13 @@ const regionalStaffStore = () =>
       user: {
         id: 2,
         email: 'regional@example.com',
-        roles: [{ name: 'OFA Regional Staff', permissions: [] }],
+        roles: [
+          {
+            name: 'OFA Regional Staff',
+            permissions: [{ codename: 'has_fra_access' }],
+          },
+        ],
+        permissions: [],
         account_approval_status: 'Approved',
         regions: [
           {
@@ -61,6 +84,7 @@ const regionalStaffStore = () =>
             stts: [
               { id: 10, name: 'Wisconsin', type: 'state' },
               { id: 11, name: 'Illinois', type: 'state' },
+              { id: 12, name: 'Ho-Chunk Nation', type: 'tribe' },
             ],
           },
         ],
@@ -178,7 +202,7 @@ describe('STTFeedbackReports', () => {
       })
     })
 
-    it('renders the H2 header with STT name and fiscal year when year is selected', async () => {
+    it('renders the H2 header with STT name, report type, and fiscal year', async () => {
       renderComponent()
 
       const yearSelect = screen.getByLabelText(/Fiscal Year/i)
@@ -188,7 +212,7 @@ describe('STTFeedbackReports', () => {
         expect(
           screen.getByRole('heading', {
             level: 2,
-            name: 'Alabama — Fiscal Year 2025 Feedback Reports',
+            name: 'Alabama — TANF/SSP Fiscal Year 2025 Feedback Reports',
           })
         ).toBeInTheDocument()
       })
@@ -215,6 +239,153 @@ describe('STTFeedbackReports', () => {
     })
   })
 
+  describe('Report Type Selection', () => {
+    it('does not show radio selector when user lacks FRA access', () => {
+      renderComponent() // dataAnalystStore has no FRA access
+
+      expect(
+        screen.queryByText('Feedback Report Type*')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows radio selector when user has FRA access', () => {
+      renderComponent(dataAnalystWithFraStore())
+
+      expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()
+      expect(screen.getByLabelText('TANF/SSP')).toBeInTheDocument()
+      expect(screen.getByLabelText('FRA')).toBeInTheDocument()
+    })
+
+    it('defaults to TANF/SSP', () => {
+      renderComponent(dataAnalystWithFraStore())
+
+      expect(screen.getByLabelText('TANF/SSP')).toBeChecked()
+    })
+
+    it('updates reference table when FRA is selected', async () => {
+      renderComponent(dataAnalystWithFraStore())
+
+      // Default shows TANF/SSP reference
+      expect(
+        screen.getByText('TANF/SSP Data Reporting Reference')
+      ).toBeInTheDocument()
+
+      // Switch to FRA
+      fireEvent.click(screen.getByLabelText('FRA'))
+
+      expect(
+        screen.getByText('FRA Data Reporting Reference')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('TANF/SSP Data Reporting Reference')
+      ).not.toBeInTheDocument()
+    })
+
+    it('updates header when FRA is selected', async () => {
+      renderComponent(dataAnalystWithFraStore())
+
+      // Select year
+      const yearSelect = screen.getByLabelText(/Fiscal Year/i)
+      fireEvent.change(yearSelect, { target: { value: '2025' } })
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: 'Alabama — TANF/SSP Fiscal Year 2025 Feedback Reports',
+          })
+        ).toBeInTheDocument()
+      })
+
+      // Switch to FRA
+      fireEvent.click(screen.getByLabelText('FRA'))
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: 'Alabama — FRA Fiscal Year 2025 Feedback Reports',
+          })
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('fetches reports with report_type when type changes', async () => {
+      renderComponent(dataAnalystWithFraStore())
+
+      const yearSelect = screen.getByLabelText(/Fiscal Year/i)
+      fireEvent.change(yearSelect, { target: { value: '2025' } })
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledWith(
+          expect.stringContaining('/reports/'),
+          expect.objectContaining({
+            params: { year: 2025, report_type: 'TANF_SSP' },
+          })
+        )
+      })
+
+      get.mockClear()
+
+      // Switch to FRA
+      fireEvent.click(screen.getByLabelText('FRA'))
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledWith(
+          expect.stringContaining('/reports/'),
+          expect.objectContaining({
+            params: { year: 2025, report_type: 'FRA' },
+          })
+        )
+      })
+    })
+
+    it('ignores FRA URL param when user lacks FRA access', async () => {
+      render(
+        <MemoryRouter initialEntries={['/feedback-reports?type=FRA&year=2025']}>
+          <Provider store={dataAnalystStore()}>
+            <STTFeedbackReports />
+          </Provider>
+        </MemoryRouter>
+      )
+
+      // Should not show radio selector
+      expect(
+        screen.queryByText('Feedback Report Type*')
+      ).not.toBeInTheDocument()
+
+      // Should fetch as TANF_SSP despite URL param
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledWith(
+          expect.stringContaining('/reports/'),
+          expect.objectContaining({
+            params: { year: 2025, report_type: 'TANF_SSP' },
+          })
+        )
+      })
+    })
+
+    it('initializes report type from URL param when user has FRA access', () => {
+      render(
+        <MemoryRouter initialEntries={['/feedback-reports?type=FRA']}>
+          <Provider store={dataAnalystWithFraStore()}>
+            <STTFeedbackReports />
+          </Provider>
+        </MemoryRouter>
+      )
+
+      expect(screen.getByLabelText('FRA')).toBeChecked()
+    })
+
+    it('regional staff always sees radio selector (has FRA via group)', () => {
+      renderComponent(regionalStaffStore())
+
+      expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()
+      expect(screen.getByLabelText('TANF/SSP')).toBeInTheDocument()
+      expect(screen.getByLabelText('FRA')).toBeInTheDocument()
+    })
+  })
+
   describe('Data Fetching', () => {
     it('does not fetch reports on mount when no year is selected', async () => {
       renderComponent()
@@ -224,7 +395,7 @@ describe('STTFeedbackReports', () => {
       })
     })
 
-    it('fetches reports when year is selected', async () => {
+    it('fetches reports with report_type when year is selected', async () => {
       renderComponent()
 
       const yearSelect = screen.getByLabelText(/Fiscal Year/i)
@@ -234,7 +405,7 @@ describe('STTFeedbackReports', () => {
         expect(get).toHaveBeenCalledWith(
           expect.stringContaining('/reports/'),
           expect.objectContaining({
-            params: { year: 2025 },
+            params: { year: 2025, report_type: 'TANF_SSP' },
           })
         )
       })
@@ -377,7 +548,7 @@ describe('STTFeedbackReports', () => {
       expect(get).toHaveBeenCalledWith(
         expect.stringContaining('/reports/'),
         expect.objectContaining({
-          params: { year: 2025 },
+          params: { year: 2025, report_type: 'TANF_SSP' },
         })
       )
 
@@ -394,7 +565,7 @@ describe('STTFeedbackReports', () => {
         expect(get).toHaveBeenCalledWith(
           expect.stringContaining('/reports/'),
           expect.objectContaining({
-            params: { year: 2024 },
+            params: { year: 2024, report_type: 'TANF_SSP' },
           })
         )
       })
@@ -415,7 +586,7 @@ describe('STTFeedbackReports', () => {
         expect(
           screen.getByRole('heading', {
             level: 2,
-            name: 'Alabama — Fiscal Year 2025 Feedback Reports',
+            name: 'Alabama — TANF/SSP Fiscal Year 2025 Feedback Reports',
           })
         ).toBeInTheDocument()
       })
@@ -426,7 +597,7 @@ describe('STTFeedbackReports', () => {
         expect(
           screen.getByRole('heading', {
             level: 2,
-            name: 'Alabama — Fiscal Year 2024 Feedback Reports',
+            name: 'Alabama — TANF/SSP Fiscal Year 2024 Feedback Reports',
           })
         ).toBeInTheDocument()
       })
@@ -547,10 +718,10 @@ describe('STTFeedbackReports', () => {
   })
 
   describe('URL Parameter Handling', () => {
-    const renderWithUrl = (url) => {
+    const renderWithUrl = (url, overrideStore) => {
       return render(
         <MemoryRouter initialEntries={[url]}>
-          <Provider store={store}>
+          <Provider store={overrideStore || store}>
             <STTFeedbackReports />
           </Provider>
         </MemoryRouter>
@@ -566,14 +737,14 @@ describe('STTFeedbackReports', () => {
       })
     })
 
-    it('fetches reports with year from URL parameter', async () => {
+    it('fetches reports with year and report_type from URL parameter', async () => {
       renderWithUrl('/feedback-reports?year=2024')
 
       await waitFor(() => {
         expect(get).toHaveBeenCalledWith(
           expect.stringContaining('/reports/'),
           expect.objectContaining({
-            params: { year: 2024 },
+            params: { year: 2024, report_type: 'TANF_SSP' },
           })
         )
       })
@@ -605,14 +776,14 @@ describe('STTFeedbackReports', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('displays H2 heading with STT name and year from URL parameter', async () => {
+    it('displays H2 heading with STT name, report type, and year from URL', async () => {
       renderWithUrl('/feedback-reports?year=2024')
 
       await waitFor(() => {
         expect(
           screen.getByRole('heading', {
             level: 2,
-            name: 'Alabama — Fiscal Year 2024 Feedback Reports',
+            name: 'Alabama — TANF/SSP Fiscal Year 2024 Feedback Reports',
           })
         ).toBeInTheDocument()
       })
@@ -670,7 +841,7 @@ describe('STTFeedbackReports', () => {
       })
     })
 
-    it('auto-fetches reports with stt param when both STT and year are selected', async () => {
+    it('auto-fetches reports with stt and report_type when both STT and year are selected', async () => {
       renderComponent(regionalStore)
 
       // Select STT via mocked ComboBox
@@ -685,13 +856,13 @@ describe('STTFeedbackReports', () => {
         expect(get).toHaveBeenCalledWith(
           expect.stringContaining('/reports/'),
           expect.objectContaining({
-            params: { year: 2025, stt: 10 },
+            params: { year: 2025, stt: 10, report_type: 'TANF_SSP' },
           })
         )
       })
     })
 
-    it('shows H2 heading with selected STT name', async () => {
+    it('shows H2 heading with selected STT name and report type', async () => {
       renderComponent(regionalStore)
 
       const sttSelect = screen.getByLabelText(/State, Tribe, or Territory/i)
@@ -704,7 +875,7 @@ describe('STTFeedbackReports', () => {
         expect(
           screen.getByRole('heading', {
             level: 2,
-            name: 'Wisconsin — Fiscal Year 2025 Feedback Reports',
+            name: 'Wisconsin — TANF/SSP Fiscal Year 2025 Feedback Reports',
           })
         ).toBeInTheDocument()
       })

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
@@ -184,7 +184,6 @@ describe('STTFeedbackReports', () => {
         expect(
           screen.getByText(/Feedback reports are produced cumulatively/i)
         ).toBeInTheDocument()
-        expect(screen.getByText(/Yun.Song@acf.hhs.gov/i)).toBeInTheDocument()
         expect(screen.getByText(/TANFData@acf.hhs.gov/i)).toBeInTheDocument()
       })
     })

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
@@ -48,16 +48,16 @@ const dataAnalystStore = () =>
     stts: { sttList: [], loading: false },
   })
 
-const dataAnalystWithFraStore = () =>
+const tribeDataAnalystStore = () =>
   mockStore({
     auth: {
       user: {
         id: 1,
         email: 'analyst@example.com',
         roles: [{ name: 'Data Analyst', permissions: [] }],
-        permissions: [{ codename: 'has_fra_access' }],
+        permissions: [],
         account_approval_status: 'Approved',
-        stt: { id: 1, name: 'Alabama' },
+        stt: { id: 100, name: 'Ho-Chunk Nation', type: 'tribe' },
       },
       authenticated: true,
     },
@@ -239,30 +239,30 @@ describe('STTFeedbackReports', () => {
   })
 
   describe('Report Type Selection', () => {
-    it('does not show radio selector when user lacks FRA access', () => {
-      renderComponent() // dataAnalystStore has no FRA access
-
-      expect(
-        screen.queryByText('Feedback Report Type*')
-      ).not.toBeInTheDocument()
-    })
-
-    it('shows radio selector when user has FRA access', () => {
-      renderComponent(dataAnalystWithFraStore())
+    it('shows radio selector for non-tribe Data Analysts', () => {
+      renderComponent() // dataAnalystStore has state STT
 
       expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()
       expect(screen.getByLabelText('TANF/SSP')).toBeInTheDocument()
       expect(screen.getByLabelText('FRA')).toBeInTheDocument()
     })
 
+    it('does not show radio selector for tribe Data Analysts', () => {
+      renderComponent(tribeDataAnalystStore())
+
+      expect(
+        screen.queryByText('Feedback Report Type*')
+      ).not.toBeInTheDocument()
+    })
+
     it('defaults to TANF/SSP', () => {
-      renderComponent(dataAnalystWithFraStore())
+      renderComponent()
 
       expect(screen.getByLabelText('TANF/SSP')).toBeChecked()
     })
 
     it('updates reference table when FRA is selected', async () => {
-      renderComponent(dataAnalystWithFraStore())
+      renderComponent()
 
       // Default shows TANF/SSP reference
       expect(
@@ -281,7 +281,7 @@ describe('STTFeedbackReports', () => {
     })
 
     it('updates header when FRA is selected', async () => {
-      renderComponent(dataAnalystWithFraStore())
+      renderComponent()
 
       // Select year
       const yearSelect = screen.getByLabelText(/Fiscal Year/i)
@@ -310,7 +310,7 @@ describe('STTFeedbackReports', () => {
     })
 
     it('fetches reports with report_type when type changes', async () => {
-      renderComponent(dataAnalystWithFraStore())
+      renderComponent()
 
       const yearSelect = screen.getByLabelText(/Fiscal Year/i)
       fireEvent.change(yearSelect, { target: { value: '2025' } })
@@ -339,10 +339,10 @@ describe('STTFeedbackReports', () => {
       })
     })
 
-    it('ignores FRA URL param when user lacks FRA access', async () => {
+    it('ignores FRA URL param for tribe users', async () => {
       render(
         <MemoryRouter initialEntries={['/feedback-reports?type=FRA&year=2025']}>
-          <Provider store={dataAnalystStore()}>
+          <Provider store={tribeDataAnalystStore()}>
             <STTFeedbackReports />
           </Provider>
         </MemoryRouter>
@@ -364,10 +364,10 @@ describe('STTFeedbackReports', () => {
       })
     })
 
-    it('initializes report type from URL param when user has FRA access', () => {
+    it('initializes report type from URL param for non-tribe users', () => {
       render(
         <MemoryRouter initialEntries={['/feedback-reports?type=FRA']}>
-          <Provider store={dataAnalystWithFraStore()}>
+          <Provider store={dataAnalystStore()}>
             <STTFeedbackReports />
           </Provider>
         </MemoryRouter>
@@ -376,7 +376,7 @@ describe('STTFeedbackReports', () => {
       expect(screen.getByLabelText('FRA')).toBeChecked()
     })
 
-    it('regional staff always sees radio selector (has FRA via group)', () => {
+    it('regional staff sees radio selector', () => {
       renderComponent(regionalStaffStore())
 
       expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()

--- a/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
+++ b/tdrs-frontend/src/components/FeedbackReports/STTFeedbackReports.test.js
@@ -23,6 +23,7 @@ jest.mock('../STTComboBox', () => {
         <option value="">- Select or Search -</option>
         <option value="Wisconsin">Wisconsin</option>
         <option value="Illinois">Illinois</option>
+        <option value="Ho-Chunk Nation">Ho-Chunk Nation</option>
       </select>
     </div>
   )
@@ -932,6 +933,44 @@ describe('STTFeedbackReports', () => {
 
       const sttSelect = screen.getByLabelText(/State, Tribe, or Territory/i)
       expect(sttSelect.value).toBe('Wisconsin')
+    })
+
+    it('hides report type selector when a tribe is selected', () => {
+      renderComponent(regionalStore)
+
+      // Initially radio should be visible (no STT selected yet)
+      expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()
+
+      // Select a tribe
+      const sttSelect = screen.getByLabelText(/State, Tribe, or Territory/i)
+      fireEvent.change(sttSelect, { target: { value: 'Ho-Chunk Nation' } })
+
+      // Radio should be hidden
+      expect(
+        screen.queryByText('Feedback Report Type*')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows radio again when switching from tribe to state STT', async () => {
+      renderComponent(regionalStore)
+
+      // Select a tribe — radio should hide
+      const sttSelect = screen.getByLabelText(/State, Tribe, or Territory/i)
+      fireEvent.change(sttSelect, { target: { value: 'Ho-Chunk Nation' } })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Feedback Report Type*')
+        ).not.toBeInTheDocument()
+      })
+
+      // Select a state — radio should reappear with TANF_SSP selected
+      fireEvent.change(sttSelect, { target: { value: 'Wisconsin' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Feedback Report Type*')).toBeInTheDocument()
+        expect(screen.getByLabelText('TANF/SSP')).toBeChecked()
+      })
     })
   })
 })

--- a/tdrs-frontend/src/components/Reports/FRAReports.jsx
+++ b/tdrs-frontend/src/components/Reports/FRAReports.jsx
@@ -8,7 +8,10 @@ import fileTypeChecker from 'file-type-checker'
 import Button from '../Button'
 import STTComboBox from '../STTComboBox'
 import { quarters } from './utils'
-import { accountIsRegionalStaff } from '../../selectors/auth'
+import {
+  accountIsRegionalStaff,
+  selectPrimaryUserRole,
+} from '../../selectors/auth'
 import {
   checkPreviewDependencies,
   removeOldPreviews,
@@ -39,6 +42,7 @@ import { PaginatedComponent } from '../Paginator/Paginator'
 import { Spinner } from '../Spinner'
 import { openFeedbackWidget } from '../../reducers/feedbackWidget'
 import { ReportsProvider, useReportsContext } from './ReportsContext'
+import FeedbackReportAlert from '../FeedbackReports/FeedbackReportAlert'
 import { accountCanSelectStt } from '../../selectors/auth'
 import { POLLING_TIMEOUT_MESSAGE } from './constants'
 import FiscalYearSelect from './components/FiscalYearSelect'
@@ -597,6 +601,8 @@ const FRAReportsContent = () => {
   const sttList = useSelector((state) => state?.stts?.sttList)
   const needsSttSelection = useSelector(accountCanSelectStt)
   const isRegionalStaff = useSelector(accountIsRegionalStaff)
+  const isDataAnalyst =
+    useSelector(selectPrimaryUserRole)?.name === 'Data Analyst'
   const userProfileStt = user?.stt?.name
 
   const fraSubmissionHistory = useSelector(
@@ -941,6 +947,13 @@ const FRAReportsContent = () => {
             reportType={fileTypeInputValue}
             reportTypeLabel={getReportTypeLabel()}
           />
+
+          {(isDataAnalyst || isRegionalStaff) && (
+            <FeedbackReportAlert
+              stt={isRegionalStaff ? stt : null}
+              reportType="FRA"
+            />
+          )}
 
           {!isRegionalStaff && (
             <>

--- a/tdrs-frontend/src/components/Reports/FRAReports.test.js
+++ b/tdrs-frontend/src/components/Reports/FRAReports.test.js
@@ -890,7 +890,7 @@ describe('FRA Reports Page', () => {
           )
         ).toBeInTheDocument()
         expect(getByText('Submit Report')).toBeInTheDocument()
-        expect(get).toHaveBeenCalledTimes(1)
+        expect(get).toHaveBeenCalledTimes(2)
       })
 
       return { ...component, ...store }

--- a/tdrs-frontend/src/components/Reports/tdr/TanfSspReports.jsx
+++ b/tdrs-frontend/src/components/Reports/tdr/TanfSspReports.jsx
@@ -47,7 +47,10 @@ const TanfSspReports = ({ stt, isRegionalStaff, isDataAnalyst }) => {
           </h2>
 
           {(isDataAnalyst || isRegionalStaff) && (
-            <FeedbackReportAlert stt={isRegionalStaff ? stt : null} />
+            <FeedbackReportAlert
+              stt={isRegionalStaff ? stt : null}
+              reportType="TANF_SSP"
+            />
           )}
 
           {localAlert.active &&

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -57,10 +57,10 @@ const AppRoutes = () => {
   const feedbackReportsTitle = userCanUploadFeedbackReports
     ? 'Upload Feedback Reports'
     : 'Feedback Reports'
-  // TODO: Change the subtitle to include wording for FRA as well TANF/SSP
+  // TODO: Change the subtitle to include wording for FRA as well as TANF/SSP
   const feedbackReportsSubtitle = userCanUploadFeedbackReports
     ? 'TANF WPR, SSP WPR, TANF & SSP Combined, and Time Limit Reports'
-    : 'Work Participation Rate and Time Limit Reports'
+    : null
 
   const setEditState = (isEditing) => {
     setIsInEditMode(isEditing)

--- a/tdrs-frontend/src/components/Routes/Routes.js
+++ b/tdrs-frontend/src/components/Routes/Routes.js
@@ -57,6 +57,7 @@ const AppRoutes = () => {
   const feedbackReportsTitle = userCanUploadFeedbackReports
     ? 'Upload Feedback Reports'
     : 'Feedback Reports'
+  // TODO: Change the subtitle to include wording for FRA as well TANF/SSP
   const feedbackReportsSubtitle = userCanUploadFeedbackReports
     ? 'TANF WPR, SSP WPR, TANF & SSP Combined, and Time Limit Reports'
     : 'Work Participation Rate and Time Limit Reports'

--- a/tdrs-frontend/src/components/Routes/Routes.test.js
+++ b/tdrs-frontend/src/components/Routes/Routes.test.js
@@ -330,8 +330,9 @@ describe('Routes.js', () => {
     expect(
       screen.getByRole('heading', { name: 'Feedback Reports' })
     ).toBeInTheDocument()
+    // STT view should not have a subtitle
     expect(
-      screen.getByText('Work Participation Rate and Time Limit Reports')
-    ).toBeInTheDocument()
+      screen.queryByText('Work Participation Rate and Time Limit Reports')
+    ).not.toBeInTheDocument()
   })
 })

--- a/tdrs-frontend/src/selectors/auth.js
+++ b/tdrs-frontend/src/selectors/auth.js
@@ -105,3 +105,8 @@ export const accountCanUploadFeedbackReports = (state) =>
   accountStatusIsApproved(state) &&
   selectUserPermissions(state).includes('view_reportsource') &&
   selectUserPermissions(state).includes('add_reportsource')
+
+// Whether the user has FRA access (via group or individual permission)
+export const accountHasFraAccess = (state) =>
+  accountStatusIsApproved(state) &&
+  selectUserPermissions(state).includes('has_fra_access')


### PR DESCRIPTION
## Summary of Changes

Pull request closes #5665

Extends the Feedback Reports UI to support FRA feedback reports alongside TANF/SSP. Previously, the feedback reports feature assumed all reports were TANF/SSP. This PR adds:

- **Admin Upload UI**: 
  - Report type radio selector (TANF/SSP or FRA) for admins to specify what type of feedback report they are uploading.
- **STT View**: 
  - Conditional report type selector for users with `has_fra_access` permission. 
  - Contextual reference table (different deadlines for FRA vs TANF/SSP).
- **In-App Alerts**: 
  - Now distinguish between TANF/SSP and FRA reports.
  - Alert added to FRA Data Files page.
  - Dismiss state is independent per report type.
- **Email template fix**: 
  - Corrected the feedback report email link to use `type` query param (matching frontend) instead of `report_type`.

## How to Test

```
cd tdrs-frontend && docker-compose up --build
cd tdrs-backend && docker-compose up --build
```

1. Open http://localhost:3000/ and sign in.
2. **Admin Upload View (sign in as OFA System Admin or DIGIT Team):**
   1. Navigate to `/feedback-reports`
   2. Verify a "Feedback Report Type" radio selector is visible with TANF/SSP and FRA options
   3. Select FRA — verify the section header updates to include "FRA" (e.g. "Fiscal Year 2025 — Upload FRA Feedback Reports")
   4. Select a fiscal year, upload a zip with a date — verify the POST includes `report_type=FRA` (check Network tab)
   5. Verify upload history only shows uploads for the selected report type
   6. Switch back to TANF/SSP — verify header, description, and history update accordingly
   7. Verify the URL contains `?type=FRA&year=2025` and can be used to deep-link directly
3. **STT View — Data Analyst WITHOUT FRA access:**
   1. Sign in as a Data Analyst without `has_fra_access` permission
   2. Navigate to `/feedback-reports`
   3. Verify NO report type radio selector is shown
   4. Verify only TANF/SSP reports are fetched (default behavior)
   5. Manually change URL to `?type=FRA` — verify it is ignored and TANF/SSP is still shown
4. **STT View — Data Analyst WITH FRA access:**
   1. Sign in as a Data Analyst with `has_fra_access` permission
   2. Navigate to `/feedback-reports`
   3. Verify the "Feedback Report Type" radio selector is visible with TANF/SSP and FRA options
   4. Select FRA — verify the reference table switches to "FRA Data Reporting Reference" with FRA-specific deadlines
   5. Verify the section header includes the report type label (e.g. "Alabama — FRA Fiscal Year 2025 Feedback Reports")
   6. Verify reports are fetched with `report_type=FRA`
5. **STT View — OFA Regional Staff:**
   1. Sign in as OFA Regional Staff
   2. Verify the report type selector is always visible (Regional Staff have FRA access via group)
   3. Select FRA — verify tribes are filtered out of the STT dropdown
   4. Select a state STT and fiscal year — verify reports fetched with `report_type=FRA`
6. **In-App Alerts — TANF Data Files page:**
   1. Sign in as a Data Analyst, navigate to TANF Data Files (`/data-files`)
   2. Select a fiscal year and quarter
   3. If feedback reports exist, verify the alert banner says "TANF/SSP Feedback Reports Available..."
   4. Verify the "review the feedback" link includes `?type=TANF_SSP&year=...`
   5. Dismiss the alert, reload — verify it stays dismissed
   6. Verify dismissing TANF/SSP alert does NOT dismiss FRA alert (independent localStorage keys)
7. **In-App Alerts — FRA Data Files page:**
   1. Navigate to FRA Data Files (`/fra-data-files`)
   2. Select a fiscal year, quarter, and file type
   3. If FRA feedback reports exist, verify the alert banner says "FRA Feedback Reports Available..."
   4. Verify the "review the feedback" link includes `?type=FRA&year=...`
8. **Email notifications:**
   1. After uploading an FRA feedback report as admin, verify the email subject contains "FRA Feedback Report Available"
   2. Verify the email link uses `?type=FRA&year=...` (not `report_type=`)


> *Demo GIF(s) and screenshots for testing procedure*

## Deliverables
_More details on how deliverables herein are assessed included [here](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [ ] Admin upload UI allows selection of report type (TANF/SSP or FRA) before uploading
+ [ ] Report type selection is sent to the backend with the upload request
+ [ ] Upload history is filtered by the selected report type
+ [ ] STT view displays reports filtered by report type
+ [ ] Reference table and description text are contextual based on selected report type
+ [ ] Users without FRA access cannot view FRA reports (no selector shown, URL manipulation rejected)
+ [ ] `FeedbackReportAlert` distinguishes between TANF/SSP and FRA feedback availability
+ [ ] FRA Data Files page displays `FeedbackReportAlert` when FRA reports are available
+ [ ] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [ ] If this PR introduces backend code changes, are they meaningfully tested?
  + [x] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [ ] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [ ] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [ ] Are backend code style checks passing on CircleCI?
+ [ ] Are frontend code style checks passing on CircleCI?
+ [ ] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic?
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review?
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?

### [Deliverable 5: Deployed](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [ ] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [x] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [x] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [ ] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [ ] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented?

### [Deliverable 8: User Research](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

N/A - no user research in this PR.