### PR TITLE
TDP Agent Configs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,8 +6,24 @@ model_provider         = "openai"
 model_reasoning_effort = "high"
 
 # Sandbox: allow writing within the workspace but not outside it.
-sandbox_mode    = "workspace-write"
-approval_policy = "on-request"
+sandbox_mode         = "workspace-write"
+approval_policy      = "on-request"
+default_permissions  = "tdp-workspace"
+
+# ---------------------------------------------------------------------------
+# Filesystem permissions
+# ---------------------------------------------------------------------------
+[permissions.tdp-workspace.filesystem]
+glob_scan_max_depth = 12
+
+[permissions.tdp-workspace.filesystem.":project_roots"]
+"." = "write"
+"**/.env" = "none"
+"**/.env.*" = "none"
+"**/*.tfvars" = "none"
+"**/*.pem" = "none"
+"**/*.rsa" = "none"
+"**/*.key" = "none"
 
 # ---------------------------------------------------------------------------
 # Shell environment
@@ -35,4 +51,5 @@ exclude = [
 # History
 # ---------------------------------------------------------------------------
 [history]
-persistence = "none"
+persistence = "save-all"
+max_bytes = 104857600 # 100 MiB

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,38 @@
+# Codex configuration for the TANF-app repository.
+# Reference: https://developers.openai.com/codex/config-advanced
+
+model                  = "gpt-5.5"
+model_provider         = "openai"
+model_reasoning_effort = "high"
+
+# Sandbox: allow writing within the workspace but not outside it.
+sandbox_mode    = "workspace-write"
+approval_policy = "on-request"
+
+# ---------------------------------------------------------------------------
+# Shell environment
+# ---------------------------------------------------------------------------
+[shell_environment_policy]
+inherit = "all"
+exclude = [
+  "AWS_*",
+  "CF_*",
+  "CLOUD_GOV_*",
+  "DATABASE_URL",
+  "DJANGO_SECRET_KEY",
+  "SECRET_*",
+  "PGPASSWORD",
+  "PGUSER",
+  "PGHOST",
+  "*_TOKEN",
+  "*_KEY",
+  "*_SECRET",
+  "*_PASSWORD",
+  "*_CREDENTIAL*",
+]
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+[history]
+persistence = "save-all"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -35,4 +35,4 @@ exclude = [
 # History
 # ---------------------------------------------------------------------------
 [history]
-persistence = "save-all"
+persistence = "none"

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,0 +1,373 @@
+# Codex rules for the TANF-app repository.
+# Derived from the global CLAUDE.md security and access guidelines.
+# Reference: https://developers.openai.com/codex/rules
+
+# ---------------------------------------------------------------------------
+# Sensitive file access — forbidden
+# "Never hardcode secrets, credentials, or API keys"
+# "Use environment variables for configuration"
+# ---------------------------------------------------------------------------
+
+# Root and backend .env files — forbidden
+prefix_rule(
+    pattern = ["cat", ".env"],
+    decision = "forbidden",
+    justification = "Do not read .env files — they may contain secrets",
+    match = [
+        "cat .env",
+        "cat .env.local",
+        "cat tdrs-backend/.env",
+    ],
+)
+
+# Frontend .env files — allowed (public build-time config only)
+prefix_rule(
+    pattern = ["cat", "tdrs-frontend/.env"],
+    decision = "allow",
+    justification = "Frontend .env files contain public build-time config, safe to read",
+)
+
+prefix_rule(
+    pattern = ["cat", ".env.example"],
+    decision = "allow",
+    justification = ".env.example is safe to read for reference",
+)
+
+# Private keys and certificates — forbidden
+prefix_rule(
+    pattern = ["cat", [".pem", ".rsa", ".key"]],
+    decision = "forbidden",
+    justification = "Never read private key or certificate files",
+)
+
+# Terraform variable files — forbidden (may contain secrets)
+prefix_rule(
+    pattern = ["cat", [".tfvars"]],
+    decision = "forbidden",
+    justification = "Terraform variable files may contain infrastructure secrets",
+)
+
+# Cloud.gov deployment var files — forbidden
+prefix_rule(
+    pattern = ["cat", "tdrs-backend/vars-backend.yml"],
+    decision = "forbidden",
+    justification = "Backend vars file contains deployment secrets",
+)
+
+prefix_rule(
+    pattern = ["cat", "tdrs-frontend/vars-frontend.yml"],
+    decision = "forbidden",
+    justification = "Frontend vars file contains deployment secrets",
+)
+
+# ---------------------------------------------------------------------------
+# Linting and testing — allow
+# "Run linters and tests before considering work complete"
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["task", "backend-lint"],
+    decision = "allow",
+    justification = "Linting is safe and encouraged before completing work",
+)
+
+prefix_rule(
+    pattern = ["task", "frontend-lint"],
+    decision = "allow",
+    justification = "Linting is safe and encouraged before completing work",
+)
+
+prefix_rule(
+    pattern = ["task", "backend-pytest"],
+    decision = "allow",
+    justification = "Running tests is safe and encouraged",
+)
+
+prefix_rule(
+    pattern = ["task", "backend-test-all"],
+    decision = "allow",
+    justification = "Running lint + tests is safe and encouraged",
+)
+
+prefix_rule(
+    pattern = ["task", "frontend-test"],
+    decision = "allow",
+    justification = "Running frontend tests is safe",
+)
+
+prefix_rule(
+    pattern = ["task", "frontend-test-cov"],
+    decision = "allow",
+    justification = "Running frontend tests with coverage is safe",
+)
+
+prefix_rule(
+    pattern = ["task", "frontend-e2e-ci-local"],
+    decision = "allow",
+    justification = "Running headless E2E tests locally is safe",
+)
+
+prefix_rule(
+    pattern = ["pre-commit", "run"],
+    decision = "allow",
+    justification = "Pre-commit hooks enforce formatting and are safe to run",
+)
+
+# ---------------------------------------------------------------------------
+# Go parser — allow build and test commands
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["make", "build"],
+    decision = "allow",
+    justification = "Building the Go parser is safe",
+)
+
+prefix_rule(
+    pattern = ["make", "test"],
+    decision = "allow",
+    justification = "Running Go parser tests is safe",
+)
+
+prefix_rule(
+    pattern = ["make", "test-coverage"],
+    decision = "allow",
+    justification = "Running Go parser coverage is safe",
+)
+
+prefix_rule(
+    pattern = ["go", "vet"],
+    decision = "allow",
+    justification = "Go vet is a safe static analysis tool",
+)
+
+prefix_rule(
+    pattern = ["go", "test"],
+    decision = "allow",
+    justification = "Running go test directly is safe",
+)
+
+prefix_rule(
+    pattern = ["go", "build"],
+    decision = "allow",
+    justification = "Building Go code is safe",
+)
+
+# ---------------------------------------------------------------------------
+# Container management — prompt before starting/stopping
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["task", "up"],
+    decision = "prompt",
+    justification = "Starting containers changes system state — confirm first",
+)
+
+prefix_rule(
+    pattern = ["task", "down"],
+    decision = "prompt",
+    justification = "Stopping containers changes system state — confirm first",
+)
+
+prefix_rule(
+    pattern = ["task", "init-backend"],
+    decision = "prompt",
+    justification = "DB initialization is destructive on first run — confirm first",
+)
+
+prefix_rule(
+    pattern = ["docker", "compose"],
+    decision = "allow",
+    justification = "Docker compose commands affect running containers — confirm first",
+)
+
+prefix_rule(
+    pattern = ["docker", "rm"],
+    decision = "forbidden",
+    justification = "Removing containers is destructive — not allowed",
+)
+
+prefix_rule(
+    pattern = ["docker", "rmi"],
+    decision = "forbidden",
+    justification = "Removing images is destructive — not allowed",
+)
+
+# ---------------------------------------------------------------------------
+# Git — safe reads, prompt on writes, forbid destructive operations
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["git", ["status", "log", "diff", "branch", "show", "blame"]],
+    decision = "allow",
+    justification = "Read-only git operations are safe",
+)
+
+prefix_rule(
+    pattern = ["git", ["add", "commit", "checkout", "switch", "stash", "rebase", "merge"]],
+    decision = "prompt",
+    justification = "Git write operations should be confirmed",
+)
+
+prefix_rule(
+    pattern = ["git", "push"],
+    decision = "prompt",
+    justification = "Pushing affects the remote — confirm first",
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--force"],
+    decision = "forbidden",
+    justification = "Force pushing can destroy remote history",
+)
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "forbidden",
+    justification = "Hard reset destroys uncommitted work",
+)
+
+prefix_rule(
+    pattern = ["git", "clean", "-f"],
+    decision = "forbidden",
+    justification = "git clean -f permanently deletes untracked files",
+)
+
+# ---------------------------------------------------------------------------
+# GitHub CLI — safe reads, prompt on mutations
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["gh", ["pr", "issue"], ["view", "list", "status"]],
+    decision = "allow",
+    justification = "Reading PR/issue info is safe",
+)
+
+prefix_rule(
+    pattern = ["gh", ["pr", "issue"], ["create", "comment", "close", "merge", "edit"]],
+    decision = "prompt",
+    justification = "Mutating PRs/issues is visible to others — confirm first",
+)
+
+# ---------------------------------------------------------------------------
+# Terraform — always prompt, forbid destructive operations
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["terraform", ["plan", "validate", "fmt"]],
+    decision = "prompt",
+    justification = "Terraform reads may access remote state — confirm first",
+)
+
+prefix_rule(
+    pattern = ["terraform", ["apply", "destroy", "import"]],
+    decision = "forbidden",
+    justification = "Terraform mutations affect live infrastructure",
+)
+
+# ---------------------------------------------------------------------------
+# Destructive shell commands — forbidden
+# "Follow the principle of least privilege"
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["rm", "-rf"],
+    decision = "forbidden",
+    justification = "Recursive forced deletion is too dangerous to allow",
+)
+
+prefix_rule(
+    pattern = ["rm", "-r"],
+    decision = "prompt",
+    justification = "Recursive deletion should be confirmed",
+)
+
+# ---------------------------------------------------------------------------
+# Forbidden network commands
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["curl"],
+    decision = "forbidden",
+    justification = "Arbitrary network requests are not allowed",
+)
+
+prefix_rule(
+    pattern = ["wget"],
+    decision = "forbidden",
+    justification = "Arbitrary network requests are not allowed",
+)
+
+# ---------------------------------------------------------------------------
+# Allowed dev tools
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["npm"],
+    decision = "allow",
+    justification = "npm commands are safe for frontend development",
+)
+
+prefix_rule(
+    pattern = ["python"],
+    decision = "allow",
+    justification = "Python commands are safe for backend development",
+)
+
+prefix_rule(
+    pattern = ["pytest"],
+    decision = "allow",
+    justification = "Running pytest directly is safe",
+)
+
+prefix_rule(
+    pattern = ["flake8"],
+    decision = "allow",
+    justification = "Flake8 linting is safe",
+)
+
+# ---------------------------------------------------------------------------
+# Read-only exploration — allow
+# ---------------------------------------------------------------------------
+
+prefix_rule(
+    pattern = ["ls"],
+    decision = "allow",
+    justification = "Listing files is safe",
+)
+
+prefix_rule(
+    pattern = ["find"],
+    decision = "allow",
+    justification = "Finding files is safe",
+)
+
+prefix_rule(
+    pattern = ["grep"],
+    decision = "allow",
+    justification = "Searching file contents is safe",
+)
+
+prefix_rule(
+    pattern = ["rg"],
+    decision = "allow",
+    justification = "Ripgrep searches are safe",
+)
+
+prefix_rule(
+    pattern = ["wc"],
+    decision = "allow",
+    justification = "Counting lines/words is safe",
+)
+
+prefix_rule(
+    pattern = ["head"],
+    decision = "allow",
+    justification = "Reading file headers is safe",
+)
+
+prefix_rule(
+    pattern = ["tail"],
+    decision = "allow",
+    justification = "Reading file tails is safe",
+)

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -8,15 +8,37 @@
 # "Use environment variables for configuration"
 # ---------------------------------------------------------------------------
 
-# Root and backend .env files — forbidden
+# Root and backend .env files — forbidden for common direct readers
 prefix_rule(
-    pattern = ["cat", ".env"],
+    pattern = [["cat", "head", "tail"], [".env", ".env.local", "tdrs-backend/.env"]],
     decision = "forbidden",
     justification = "Do not read .env files — they may contain secrets",
     match = [
         "cat .env",
-        "cat .env.local",
-        "cat tdrs-backend/.env",
+        "head .env.local",
+        "tail tdrs-backend/.env",
+    ],
+)
+
+prefix_rule(
+    pattern = ["rg", ".", [".env", ".env.local", "tdrs-backend/.env"]],
+    decision = "forbidden",
+    justification = "Do not search .env files — they may contain secrets",
+    match = [
+        "rg . .env",
+        "rg . .env.local",
+        "rg . tdrs-backend/.env",
+    ],
+)
+
+prefix_rule(
+    pattern = ["grep", ".", [".env", ".env.local", "tdrs-backend/.env"]],
+    decision = "forbidden",
+    justification = "Do not search .env files — they may contain secrets",
+    match = [
+        "grep . .env",
+        "grep . .env.local",
+        "grep . tdrs-backend/.env",
     ],
 )
 
@@ -299,19 +321,19 @@ prefix_rule(
 )
 
 # ---------------------------------------------------------------------------
-# Allowed dev tools
+# Development tools requiring review
 # ---------------------------------------------------------------------------
 
 prefix_rule(
     pattern = ["npm"],
-    decision = "allow",
-    justification = "npm commands are safe for frontend development",
+    decision = "prompt",
+    justification = "npm can run arbitrary scripts or mutate workspace files — confirm first",
 )
 
 prefix_rule(
     pattern = ["python"],
-    decision = "allow",
-    justification = "Python commands are safe for backend development",
+    decision = "prompt",
+    justification = "Python can read sensitive files or mutate workspace files — confirm first",
 )
 
 prefix_rule(
@@ -327,7 +349,7 @@ prefix_rule(
 )
 
 # ---------------------------------------------------------------------------
-# Read-only exploration — allow
+# Read-only exploration
 # ---------------------------------------------------------------------------
 
 prefix_rule(
@@ -344,14 +366,14 @@ prefix_rule(
 
 prefix_rule(
     pattern = ["grep"],
-    decision = "allow",
-    justification = "Searching file contents is safe",
+    decision = "prompt",
+    justification = "grep can expose sensitive file contents — confirm first",
 )
 
 prefix_rule(
     pattern = ["rg"],
-    decision = "allow",
-    justification = "Ripgrep searches are safe",
+    decision = "prompt",
+    justification = "rg can expose sensitive file contents — confirm first",
 )
 
 prefix_rule(
@@ -362,12 +384,12 @@ prefix_rule(
 
 prefix_rule(
     pattern = ["head"],
-    decision = "allow",
-    justification = "Reading file headers is safe",
+    decision = "prompt",
+    justification = "head can expose sensitive file contents — confirm first",
 )
 
 prefix_rule(
     pattern = ["tail"],
-    decision = "allow",
-    justification = "Reading file tails is safe",
+    decision = "prompt",
+    justification = "tail can expose sensitive file contents — confirm first",
 )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Code Quality
+
+- Write clear, self-documenting code with meaningful names
+- Keep functions small and focused on a single responsibility
+- Add comments only when explaining *why*, not *what*
+- Follow existing patterns and conventions in the codebase
+- Remove dead code rather than commenting it out
+
+## Making Changes
+
+- Read and understand existing code before modifying
+- Make minimal, targeted changes that solve the specific problem
+- Preserve existing formatting and style conventions
+- Update tests when changing functionality
+- Run linters and tests before considering work complete
+- Always use type hinting when applicable
+
+## Testing
+
+- Write tests that verify behavior, not implementation details
+- Cover edge cases and error conditions
+- Keep tests independent and deterministic
+- Maintain existing test coverage levels
+
+## Security
+
+- Never hardcode secrets, credentials, or API keys
+- Use environment variables for configuration
+- Validate and sanitize all inputs
+- Follow the principle of least privilege
+
+## Problem Solving
+
+- Identify root causes before implementing fixes
+- Prefer simple solutions over clever ones
+- Ask clarifying questions when requirements are ambiguous
+- Document assumptions and decisions
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are always created in GitHub Issues for this repo. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default mattpocock/skills triage label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a multi-context monorepo with a root `CONTEXT-MAP.md` pointing to subsystem context files. See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,14 @@
+# Context Map
+
+This repo is a multi-context monorepo. Read the root `CONTEXT.md` first, then read the context file for the subsystem you are touching.
+
+| Context | Path | Notes |
+| --- | --- | --- |
+| Repo-wide | `CONTEXT.md` | Shared product, compliance, deployment, and cross-system language |
+| Django API and Celery workers | `tdrs-backend/CONTEXT.md` | Python/Django backend, API behavior, async jobs, parsing orchestration |
+| Keycloak initiative | `tdrs-backend/keycloak/CONTEXT.md` | Authentication and identity work related to Keycloak |
+| PLG configuration | `tdrs-backend/plg/CONTEXT.md` | PLG configuration and related backend integration |
+| Go parser service | `tdrs-services/parser/CONTEXT.md` | Go parser service under `tdrs-services/parser` |
+| React frontend | `tdrs-frontend/CONTEXT.md` | CRA React frontend and user-facing workflows |
+
+If a change crosses contexts, read each relevant context file before editing.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# TANF App Context
+
+This repository contains the TANF Data Reporting System application and supporting services.
+
+## Product Boundary
+
+The system supports TANF data collection, validation, submission, reporting, operational monitoring, and related user workflows.
+
+## Repository Shape
+
+This is a multi-context monorepo. Read `CONTEXT-MAP.md` to choose the subsystem context before making changes.
+
+The main contexts are:
+
+- `tdrs-backend/`: Django API, Python backend logic, Celery workers, parsing orchestration, and backend deployment assets.
+- `tdrs-backend/keycloak/`: Keycloak initiative for authentication and identity work.
+- `tdrs-backend/plg/`: PLG configuration and observability deployment assets.
+- `tdrs-services/parser/`: Go parser service.
+- `tdrs-frontend/`: CRA React frontend.
+
+## Cross-Cutting Concerns
+
+- Security and compliance requirements matter across the repository.
+- Data validation and parsing behavior should be treated as product behavior, not only implementation detail.
+- Changes that affect user access, reporting workflows, or submitted data should be reviewed against relevant docs under `docs/`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the project for the New TANF Data Portal, which will replace the lega
 
 Our vision is to build a new, secure, web-based data reporting system to improve the federal reporting experience for TANF grantees and federal staff. The new system will allow grantees to easily submit accurate data and be confident that they have fulfilled their reporting requirements. This will reduce the burden on all users, improve data quality, lead to better policy and program decision-making, and ultimately help low-income families.
 
---- 
+---
 
 ## Current Build
 
@@ -12,7 +12,7 @@ Our vision is to build a new, secure, web-based data reporting system to improve
 |---|---|---|---|
 |**Build**| [![CircleCI-Dev](https://circleci.com/gh/raft-tech/TANF-app/tree/develop.svg?style=shield)](https://circleci.com/gh/raft-tech/TANF-app/tree/develop) | [![CircleCI-HHS](https://circleci.com/gh/HHS/TANF-app/tree/main.svg?style=shield)](https://circleci.com/gh/HHS/TANF-app/tree/main)|[![CircleCI-HHS](https://circleci.com/gh/HHS/TANF-app/tree/master.svg?style=shield)](https://circleci.com/gh/HHS/TANF-app/tree/master)
 |**Security**| [Dependabot-Dev](https://github.com/raft-tech/TANF-app/security/dependabot) | [Advisories-HHS](https://github.com/HHS/TANF-app/security/advisories) | [Advisories-HHS](https://github.com/HHS/TANF-app/security/advisories)
-|**Frontend Coverage**| [![Codecov-Frontend-Dev](https://codecov.io/gh/raft-tech/TANF-app/branch/develop/graph/badge.svg?flag=dev-frontend)](https://codecov.io/gh/raft-tech/TANF-app?flag=dev-frontend) | [![Codeco-Frontend-HHS](https://codecov.io/gh/HHS/TANF-app/branch/main/graph/badge.svg?flag=main-frontend)](https://codecov.io/gh/HHS/TANF-app?flag=main-frontend)   | [![Codeco-Frontend-HHS](https://codecov.io/gh/HHS/TANF-app/branch/master/graph/badge.svg?flag=master-frontend)](https://codecov.io/gh/HHS/TANF-app?flag=master-frontend) 
+|**Frontend Coverage**| [![Codecov-Frontend-Dev](https://codecov.io/gh/raft-tech/TANF-app/branch/develop/graph/badge.svg?flag=dev-frontend)](https://codecov.io/gh/raft-tech/TANF-app?flag=dev-frontend) | [![Codeco-Frontend-HHS](https://codecov.io/gh/HHS/TANF-app/branch/main/graph/badge.svg?flag=main-frontend)](https://codecov.io/gh/HHS/TANF-app?flag=main-frontend)   | [![Codeco-Frontend-HHS](https://codecov.io/gh/HHS/TANF-app/branch/master/graph/badge.svg?flag=master-frontend)](https://codecov.io/gh/HHS/TANF-app?flag=master-frontend)
 |**Backend Coverage**|  [![Codecov-Backend-Dev](https://codecov.io/gh/raft-tech/TANF-app/branch/develop/graph/badge.svg?flag=dev-backend)](https://codecov.io/gh/raft-tech/TANF-app/branch/develop?flag=dev-backend)|   [![Codecov-Backend-HHS]( https://codecov.io/gh/HHS/TANF-app/branch/main/graph/badge.svg?flag=main-backend)](https://codecov.io/gh/HHS/TANF-app/branch/main?flag=main-backend) |  [![Codecov-Backend-HHS]( https://codecov.io/gh/HHS/TANF-app/branch/master/graph/badge.svg?flag=master-backend)](https://codecov.io/gh/HHS/TANF-app/branch/master?flag=master-backend)
 
 [Link to Current Development Deployments](./docs/Technical-Documentation/TDP-environments-README.md)
@@ -42,20 +42,26 @@ Our vision is to build a new, secure, web-based data reporting system to improve
     + **[Zenhub](https://app.zenhub.com/workspaces/tdrs-sprint-board-5f18ab06dfd91c000f7e682e/board?repos=281707402)**: Tracking issues
     + **[Product Updates](./product-updates)**: communication on project updates and research findings to the broader TDP stakeholders and target users
 
+## Working With Agents
+
+This repo includes agent-facing context files to help coding agents understand the monorepo layout, subsystem boundaries, issue tracker workflow, and domain vocabulary. Start with [AGENTS.md](./AGENTS.md), [CONTEXT.md](./CONTEXT.md), [CONTEXT-MAP.md](./CONTEXT-MAP.md), and the supporting files under [docs/agents](./docs/agents).
+
+For a stronger starting point, contributors using local coding agents are encouraged to set up [mattpocock/skills](https://github.com/mattpocock/skills) on their machine with the skills installed under `~/.agents/skills/`. Those skills can then use this repo's agent context files when creating issues, triaging work, diagnosing bugs, practicing TDD, or improving architecture.
+
 ## Infrastructure
 
 TDP Uses Infrastructure as Code (IaC) and DevSecOps automation
 
 ### **Authentication**
 
-TDP application requires strong multi-factor authentication (MFA) for all users, and Personal Identity Verification (PIV) authentication must be used as the 2nd factor for all internal ACF staff. 
-**ACF AMS** authentication service is being used for ACF users, and **Login.gov** authentication service is being used for external users. 
+TDP application requires strong multi-factor authentication (MFA) for all users, and Personal Identity Verification (PIV) authentication must be used as the 2nd factor for all internal ACF staff.
+**ACF AMS** authentication service is being used for ACF users, and **Login.gov** authentication service is being used for external users.
 
 See [Architecture Decision Record 005 - Application Authentication](./docs/Technical-Documentation/Architecture-Decision-Record/005-application-authentication.md) - for more details.
 
 ### **Cloud Environment**
 
-[Cloud.gov](https://cloud.gov/) is being used as the cloud environment. This platform-as-a-service (PaaS) removes almost all of the infrastructure monitoring and maintenance from the system, is already procured for OFA, and has a FedRAMP Joint Authorization Board Provisional Authority to Operate (JAB P-ATO) on file. 
+[Cloud.gov](https://cloud.gov/) is being used as the cloud environment. This platform-as-a-service (PaaS) removes almost all of the infrastructure monitoring and maintenance from the system, is already procured for OFA, and has a FedRAMP Joint Authorization Board Provisional Authority to Operate (JAB P-ATO) on file.
 
 See [Architecture Decision Record 003 - Application Hosting](./docs/Technical-Documentation/Architecture-Decision-Record/003-Application-hosting.md) - for more details.
 
@@ -73,7 +79,7 @@ The application is continuously deployed to the dev, staging, or prod environmen
 
 See [Architecture Decision Record 008 - Deployment Flow](docs/Technical-Documentation/Architecture-Decision-Record/008-deployment-flow.md) - for more details.
 
-## Accessibility 
+## Accessibility
 TDP is developed to be (at minimum) compliant with Section 508 of the Rehabilitation Act which mandates a WCAG 2.0 AA standard. To enable a left-shifted approach to accessibility and aid the team in implementing accessible solutions, Raft maintains an [Accessibility Guide](https://hackmd.io/@mreiter/ByVulbdQd) to help enable those less familiar with a11y testing up and running. For additional documentation & resources regarding project accessibility, see [QASP Accessibility Expectations](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#deliverable-4-accessibility).
 
 ## Points of Contact

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,42 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root for repo-wide product and system language.
+- **`CONTEXT-MAP.md`** at the repo root to find subsystem-specific context files.
+- **Subsystem `CONTEXT.md` files** for each area involved in the change.
+- **`docs/Technical-Documentation/`** if it exists for system-wide decisions.
+- **`<subsystem>/docs/adr/`** if it exists for context-specific decisions.
+
+If any ADR directory does not exist, proceed silently. Do not flag its absence or suggest creating one upfront. The producer skill (`/grill-with-docs`) creates ADRs lazily when decisions actually get resolved.
+
+## File structure
+
+This repo uses a multi-context layout:
+
+```text
+/
+├── CONTEXT.md
+├── CONTEXT-MAP.md
+├── docs/agents/
+├── tdrs-backend/
+│   ├── CONTEXT.md
+│   ├── keycloak/CONTEXT.md
+│   └── plg/CONTEXT.md
+├── tdrs-services/
+│   └── parser/CONTEXT.md
+└── tdrs-frontend/
+    └── CONTEXT.md
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term as defined in the relevant `CONTEXT.md`. Do not drift to synonyms the glossary explicitly avoids.
+
+If the concept you need is not in the glossary yet, that is a signal: either you are inventing language the project does not use, or there is a real gap to note for `/grill-with-docs`.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo always live as GitHub issues. Use the `gh` CLI for issue operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the GitHub repo from `git remote -v` and the current checkout. If multiple GitHub remotes are available, default to the active repo for the current branch unless the user specifies a different GitHub repo.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+Edit the right-hand column to match the tracker vocabulary if the repo changes labels later.

--- a/tdrs-backend/CONTEXT.md
+++ b/tdrs-backend/CONTEXT.md
@@ -1,0 +1,18 @@
+# Backend Context
+
+This context covers the Django API, Python backend code, Celery workers, parsing orchestration, backend tests, and backend deployment assets under `tdrs-backend/`.
+
+## Boundaries
+
+- API behavior and backend application logic live here.
+- Celery worker behavior and asynchronous jobs live here.
+- Backend parsing orchestration lives here, even when parser implementation details are delegated to another service.
+- Authentication integration touches this context, but Keycloak-specific configuration and deployment details are documented in `tdrs-backend/keycloak/CONTEXT.md`.
+- PLG observability configuration is documented in `tdrs-backend/plg/CONTEXT.md`.
+
+## Read With
+
+- Root `CONTEXT.md`
+- `CONTEXT-MAP.md`
+- Relevant technical docs under `docs/Technical-Documentation/`
+- Relevant backend README or module-level docs near the code being changed

--- a/tdrs-backend/keycloak/CONTEXT.md
+++ b/tdrs-backend/keycloak/CONTEXT.md
@@ -1,0 +1,90 @@
+# Keycloak Context
+
+This context covers the Keycloak initiative under `tdrs-backend/keycloak/`.
+
+## Boundaries
+
+- Keycloak acts as the OpenID Connect broker between TDP and external identity providers, currently Login.gov and AMS.
+- Keycloak container, deployment scripts, realm exports, IdP configuration, nginx proxy config, and cloud.gov manifest assets live here.
+- Django remains the source of truth for TDP user information. Keycloak should receive synced user attributes and group memberships from Django; do not treat Keycloak as authoritative for application user state.
+- Authentication and identity changes usually cross `tdrs-backend/`, `tdrs-backend/keycloak/`, and `tdrs-frontend/`.
+- Treat user access, roles, identity-provider behavior, client secrets, signing keys, and realm exports as security-sensitive.
+
+## Important Paths
+
+- `README.md`: setup, environment variables, realm configuration, Django integration, deployment, and troubleshooting overview.
+- `keycloak-operations.md`: operational runbook for deployment, health checks, troubleshooting, Grafana SSO, and sync failures.
+- `realm-configs/`: checked-in realm exports for local/dev, staging, and production.
+- `select-realm-config.sh`: selects the environment-specific realm export before Keycloak starts.
+- `configure-idps.sh`: applies runtime-sensitive IdP configuration such as Login.gov signing key and ACR values.
+- `deploy.sh`: cloud.gov deployment script; sets routes, network policies, and post-start IdP configuration.
+- `entrypoint.sh`: starts Keycloak on an internal port and nginx on the Cloud Foundry `$PORT`.
+- `nginx.conf`: reverse proxy in front of Keycloak, including headers needed for the admin console.
+
+## Runtime Model
+
+- Browser login starts from the frontend, routes through Django `/v2/` auth endpoints, redirects to Keycloak, then to the upstream IdP.
+- Keycloak brokers external IdPs; Django handles the OIDC callback and creates the application session cookie.
+- `KEYCLOAK_BROWSER_URL` is browser-facing and is used for authorization and logout redirects.
+- `KEYCLOAK_SERVER_URL` is server-to-server and is used by Django for token exchange, userinfo, JWKS, admin API calls, and user sync.
+- Local Docker defines `keycloak-pg`, `keycloak`, and `keycloak-configure` services in `tdrs-backend/docker-compose.yml`.
+- In cloud.gov, Keycloak has a public route for browser/admin access and an internal route for backend/celery server-to-server traffic.
+
+## Django Integration
+
+- `tdpservice.users.oidc.KeycloakOIDCBackend` is the custom mozilla-django-oidc backend.
+- `tdpservice.users.keycloak_client.KeycloakSyncClient` syncs Django user state into Keycloak through the Admin REST API.
+- `tdpservice.users.keycloak_sync` registers Django signal handlers for user saves and group membership changes.
+- `tdpservice.users.tasks.reconcile_keycloak_users` periodically reconciles active Django users into Keycloak via Celery Beat.
+- `tdpservice.users.management.commands.sync_users_to_keycloak` performs a manual bulk sync.
+- `settings/common.py` defines the Keycloak and mozilla-django-oidc settings, including the canary `KEYCLOAK_AUTH_PERCENTAGE`.
+
+## User Sync Rules
+
+- Django is authoritative for application users, user attributes, approval status, STT/region assignment, and Django group membership.
+- Sync is enabled by `KEYCLOAK_SYNC_ENABLED`.
+- On `User` save, Django syncs user attributes such as `login_gov_uuid`, `hhs_id`, `stt_id`, `account_approval_status`, and `region_ids` to Keycloak.
+- On Django group membership changes, Django syncs mapped Keycloak group memberships.
+- Bulk sync only syncs active Django users.
+- Sync finds Keycloak users by exact email. If the user has not logged in through Keycloak yet and does not exist in Keycloak, sync is skipped.
+- The sync client sets absolute state, not deltas; group sync removes current Keycloak groups before adding groups that match current Django state.
+
+## Group Mapping
+
+The Django-to-Keycloak group mapping lives in `tdpservice.users.keycloak_client.DJANGO_TO_KC_GROUP`.
+
+| Django Group | Keycloak Group |
+| --- | --- |
+| OFA Admin | ofa-admin |
+| OFA System Admin | ofa-system-admin |
+| Data Analyst | data-analyst |
+| OFA Regional Staff | ofa-regional-staff |
+| Developer | developer |
+| ACF OCIO | acf-ocio |
+| DIGIT Team | digit-team |
+
+## Authentication Rules
+
+- Users are looked up by IdP-specific claims first: `hhs_id` for AMS and `login_gov_uuid` for Login.gov, then by normalized email.
+- `@acf.hhs.gov` users must authenticate through AMS, not Login.gov.
+- Inactive and deactivated users are rejected during login.
+- Keycloak includes required claims in the ID token through protocol mappers, so `KeycloakOIDCBackend.get_userinfo` uses the ID token payload directly.
+
+## Test Strategy
+
+- Keycloak OIDC backend tests live in `tdrs-backend/tdpservice/users/test/test_oidc.py`.
+- Keycloak sync tests live in `tdrs-backend/tdpservice/users/test/test_keycloak_sync.py`.
+- Run backend tests through the backend pytest workflow; focus the test path when changing only Keycloak integration code.
+
+## Read With
+
+- Root `CONTEXT.md`
+- `CONTEXT-MAP.md`
+- `tdrs-backend/CONTEXT.md`
+- Keycloak README and operations docs in this directory
+- Relevant authentication docs under `docs/Technical-Documentation/`
+- `tdrs-backend/tdpservice/users/oidc.py`
+- `tdrs-backend/tdpservice/users/keycloak_client.py`
+- `tdrs-backend/tdpservice/users/keycloak_sync.py`
+- `tdrs-backend/tdpservice/users/tasks.py`
+- `tdrs-backend/docker-compose.yml`

--- a/tdrs-backend/plg/CONTEXT.md
+++ b/tdrs-backend/plg/CONTEXT.md
@@ -1,0 +1,56 @@
+# PLG Context
+
+This context covers PLG configuration under `tdrs-backend/plg/`.
+
+## Boundaries
+
+- Grafana, Loki, Mimir, Prometheus, Tempo, Alloy, Alertmanager, and related deployment configuration live here.
+- Grafana authentication is brokered through Keycloak OIDC using the `tdp-grafana` client.
+- Monitoring changes should preserve least-privilege access and avoid exposing sensitive data.
+- Operational dashboards and alerts should reflect production support needs, not only local development convenience.
+- PLG auth changes are security-sensitive and usually require reading the Keycloak context too.
+
+## Important Paths
+
+- `grafana/custom.ini`: deployed Grafana configuration, including Keycloak generic OAuth.
+- `grafana/custom.local.ini`: local Grafana configuration, including local Keycloak generic OAuth.
+- `grafana/dashboards/keycloak_metrics.json`: Keycloak authentication and JVM metrics dashboard.
+- `grafana/dashboards/keycloak_capacity.json`: Keycloak capacity dashboard.
+- `prometheus/prometheus.yml`: deployed Prometheus scrape configuration.
+- `prometheus/prometheus.local.yml`: local Prometheus scrape configuration.
+- `deploy.sh`: PLG deployment orchestration.
+
+## Grafana SSO
+
+- Grafana uses `[auth.generic_oauth]` with `name = Keycloak` and `client_id = tdp-grafana`.
+- Keycloak is the OIDC broker for Grafana SSO; Login.gov and AMS are available through Keycloak, and local developer accounts can exist directly in Keycloak.
+- Django remains the source of truth for TDP user information. Grafana access depends on Keycloak token claims that are populated from Django-to-Keycloak sync.
+- Users must have `account_approval_status == 'Approved'` and a required Keycloak group claim, otherwise Grafana login is denied.
+- `role_attribute_strict = true`, so users without a matching role expression do not receive fallback access.
+- Deployed Grafana disables basic auth; local Grafana keeps basic auth enabled as a debugging fallback.
+
+Grafana role and org mapping is configured in `grafana/custom.ini` and `grafana/custom.local.ini`:
+
+| Keycloak Group | Grafana Org | Grafana Role |
+| --- | --- | --- |
+| `ofa-system-admin` | Admin | Admin |
+| `developer` | Admin | Admin |
+| `digit-team` | DIGIT | Editor |
+
+Deployed configuration maps `digit-team` to org ID 3. Local configuration maps `digit-team` to org ID 2.
+
+## Keycloak URL Split
+
+- Grafana browser redirects use Keycloak's public/browser-facing URL for `auth_url` and logout.
+- Grafana token and userinfo calls use Keycloak's internal/server-to-server URL for `token_url` and `api_url`.
+- In cloud.gov, Grafana needs a network policy allowing it to reach Keycloak on the internal route.
+
+## Read With
+
+- Root `CONTEXT.md`
+- `CONTEXT-MAP.md`
+- `tdrs-backend/keycloak/CONTEXT.md`
+- PLG README and component-specific files in this directory
+- Relevant observability and deployment docs under `docs/Technical-Documentation/`
+- `docs/Technical-Documentation/auth-architecture.md`
+- `docs/Technical-Documentation/Architecture-Decision-Record/005-application-authentication.md`

--- a/tdrs-frontend/CONTEXT.md
+++ b/tdrs-frontend/CONTEXT.md
@@ -1,0 +1,16 @@
+# Frontend Context
+
+This context covers the CRA React frontend under `tdrs-frontend/`.
+
+## Boundaries
+
+- User-facing workflows, React components, frontend routing, client-side state, frontend tests, and frontend build configuration live here.
+- Authentication and user access workflows may also require reading the backend and Keycloak contexts.
+- Data submission, validation messaging, and reporting screens should align with backend behavior and product terminology.
+
+## Read With
+
+- Root `CONTEXT.md`
+- `CONTEXT-MAP.md`
+- Relevant frontend README and source-level docs
+- Relevant product, UX, and technical docs under `docs/`

--- a/tdrs-services/parser/CONTEXT.md
+++ b/tdrs-services/parser/CONTEXT.md
@@ -1,0 +1,62 @@
+# Go Parser Service Context
+
+This context covers the Go parser service under `tdrs-services/parser/`.
+
+## Boundaries
+
+- The Go parser replaces the Python parser for TANF, SSP, Tribal TANF, and FRA data files.
+- Parser implementation, parser-specific Go tests, parser configuration, SQLC inputs, generated DB access code, and parser service Docker assets live here.
+- The parser uses a YAML-driven pipeline to decode, parse, validate, and write records.
+- Production-like local integration runs the parser in Celery mode as the `go-parser` Docker Compose service from `tdrs-backend/docker-compose.yml`.
+- Parsing output, validation results, task status, and database writes are product behavior and may affect backend workflows.
+- Cross-service changes should also read `tdrs-backend/CONTEXT.md`.
+
+## Important Paths
+
+- `cmd/parser/`: main parser binary.
+- `cmd/docgen/`: validation error documentation generator.
+- `config/parser.yaml`: primary parser configuration.
+- `config/validation/validators.yaml`: validation rule configuration.
+- `internal/decoder/`: CSV, XLSX, positional, and row decoding.
+- `internal/parser/`: parsing, transformation, sorting, accumulation, and orchestration.
+- `internal/pipeline/`: worker pool, routing, and pipeline execution.
+- `internal/validation/`: validation registry, execution, environment, and results.
+- `internal/db/`: SQLC-generated and DB-facing code.
+- `schema.sql`, `query.sql`, `sqlc.yaml`: SQLC schema/query/code generation inputs.
+- `docs/architecture.md`: parser architecture overview.
+
+## Read With
+
+- Root `CONTEXT.md`
+- `CONTEXT-MAP.md`
+- Backend context when parser behavior is consumed by Django or Celery workflows
+- Parser README or package-level documentation near the code being changed
+- `tdrs-backend/pytest-go-parser.ini` and `tdrs-backend/tdpservice/parsers/test/integration/` when changing Django/Go parser integration behavior
+
+## Test Strategy
+
+There are two distinct integration-test surfaces:
+
+- Go package tests live under `tdrs-services/parser/internal/**` and run from `tdrs-services/parser`.
+- Django-to-Go parser integration tests live under `tdrs-backend/tdpservice/parsers/test/integration/` and are executed by pytest in a separate pytest suite.
+
+Use these commands for the common cases:
+
+```sh
+# Go unit tests
+cd tdrs-services/parser
+make test
+
+# Backend live integration suite for Django fixtures + live Go parser worker
+task backend-pytest-go-integration
+```
+
+The backend integration suite is intentionally isolated from the default `task backend-pytest` run. It uses `tdrs-backend/pytest-go-parser.ini`, `tdpservice.settings.go_parser_integration`, and the `GoParserIntegration` Django configuration so pytest fixtures are committed to the shared Docker database that the Go parser worker can observe.
+
+The `go-parser` Docker Compose service is built from `../tdrs-services/parser` and runs with:
+
+```sh
+--server.mode=celery --storage.source=s3
+```
+
+It consumes Redis/Celery work from the `go-parser` queue, connects to the shared PostgreSQL database, and reads files from the LocalStack-backed S3 bucket in local integration.


### PR DESCRIPTION
## Summary of Changes
- It is time to start defining these things at the repo level so that whatever agents our teammates are using they are building/updating with the same guiding context.
- I recommended using mattpocock/skills as they are very useful though not a requirement

I'd love for us to iterate on this a bit more together. I had the contexts also update with incoming work that hasn't merged yet but is important enough that it should live in the context now as opposed to later. E.g. Go parser `pytest` integration test suite, Keycloak & PLG SSO info.

## How to Test

- Read and make suggestions
- Try out mattpocock/skills if interested
- Should we add a context.md for KC?
