### PR TITLE
Hotfix: SET Handler using `subject_type` instead of `new-value`

### DIFF
--- a/tdrs-backend/tdpservice/security/event_handler.py
+++ b/tdrs-backend/tdpservice/security/event_handler.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.utils import timezone
 
 from tdpservice.security.models import SecurityEventToken, SecurityEventType
@@ -59,15 +61,34 @@ class SecurityEventHandler:
         """Get the old and new emails from the event data."""
         event_data = security_event.event_data
         subject = event_data.get("subject")
-        new_email = subject.get("subject_type")
         old_email = subject.get("email")
+        new_email = event_data.get("new-value")
         return new_email, old_email
+
+    def _is_valid_email(email):
+        """Return whether the value is formatted as an email address."""
+        try:
+            validate_email(email)
+        except ValidationError:
+            return False
+        return True
 
     def _handle_email_changed(security_event):
         """Handle email-changed event."""
         new_email, old_email = SecurityEventHandler._get_emails(security_event)
-
         user = security_event.user
+
+        if not new_email:
+            logger.info(
+                f"User {user.username} identifier changed for email {old_email}; no new email provided"
+            )
+            return
+
+        if not SecurityEventHandler._is_valid_email(new_email):
+            raise ValueError(
+                f"Invalid new email value in identifier-changed event: {new_email}"
+            )
+
         user.email = new_email
         user.username = new_email
         user.save()
@@ -124,17 +145,17 @@ class SecurityEventHandler:
                     "No user found with login_gov_uuid: {}".format(subject.get("sub"))
                 )
         elif "email" in subject:
-            # Check both emails in the subject to see if we have the user
+            if subject.get("subject_type") != "email":
+                raise ValueError(
+                    "Email subject security event must have subject_type 'email'."
+                )
+
             user_qset = User.objects.filter(username=subject.get("email"))
             if user_qset.exists() and user_qset.count() == 1:
                 return user_qset.first()
 
-            user_qset = User.objects.filter(username=subject.get("subject_type"))
-            if user_qset.exists() and user_qset.count() == 1:
-                return user_qset.first()
-
             raise ValueError(
-                "No user found with the provided 'email' or 'subject_type' in subject of security event."
+                "No user found with the provided 'email' in subject of security event."
             )
 
         raise ValueError("No user info found in subject of security event.")

--- a/tdrs-backend/tdpservice/security/event_handler.py
+++ b/tdrs-backend/tdpservice/security/event_handler.py
@@ -4,8 +4,6 @@ import logging
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from django.utils import timezone
 
 from tdpservice.security.models import SecurityEventToken, SecurityEventType
@@ -65,34 +63,17 @@ class SecurityEventHandler:
         new_email = event_data.get("new-value")
         return new_email, old_email
 
-    def _is_valid_email(email):
-        """Return whether the value is formatted as an email address."""
-        try:
-            validate_email(email)
-        except ValidationError:
-            return False
-        return True
-
     def _handle_email_changed(security_event):
-        """Handle email-changed event."""
+        """Handle email-changed event without mutating the user record."""
         new_email, old_email = SecurityEventHandler._get_emails(security_event)
         user = security_event.user
-
-        if not new_email:
-            logger.info(
-                f"User {user.username} identifier changed for email {old_email}; no new email provided"
-            )
-            return
-
-        if not SecurityEventHandler._is_valid_email(new_email):
-            raise ValueError(
-                f"Invalid new email value in identifier-changed event: {new_email}"
-            )
-
-        user.email = new_email
-        user.username = new_email
-        user.save()
-        logger.info(f"User changed email from {old_email} to {new_email}")
+        logger.info(
+            "User %s identifier changed for email %s; SET new-value=%s. "
+            "User email is synced from OIDC claims on login.",
+            user.username,
+            old_email,
+            new_email,
+        )
 
     def _handle_email_recycled(security_event):
         """Handle email-recycled event."""
@@ -133,6 +114,56 @@ class SecurityEventHandler:
         SecurityEventType.REPROOF_COMPLETE: _handle_reproof_complete,
     }
 
+    user_mutation_event_types = {
+        SecurityEventType.ACCOUNT_DISABLED,
+        SecurityEventType.ACCOUNT_ENABLED,
+        SecurityEventType.ACCOUNT_PURGED,
+    }
+
+    @classmethod
+    def _get_issued_at(cls, decoded_jwt):
+        """Convert the SET issued-at timestamp to a datetime."""
+        iat_timestamp = decoded_jwt.get("iat")
+        if not iat_timestamp:
+            return None
+
+        try:
+            return datetime.fromtimestamp(iat_timestamp, tz=dt_timezone.utc)
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Error converting timestamp {iat_timestamp}: {e}")
+            return None
+
+    @classmethod
+    def _create_security_event(cls, user, event_type, event_data, decoded_jwt):
+        """Create a SecurityEventToken for a known or unmatched event subject."""
+        subject = event_data.get("subject", {})
+        return SecurityEventToken.objects.create(
+            user=user,
+            email=user.email if user else subject.get("email"),
+            event_type=event_type,
+            event_data=event_data,
+            jwt_id=decoded_jwt.get("jti"),
+            issuer=decoded_jwt.get("iss"),
+            issued_at=cls._get_issued_at(decoded_jwt),
+        )
+
+    @classmethod
+    def _mark_processed(cls, security_event):
+        """Mark a security event as processed."""
+        security_event.processed = True
+        security_event.processed_at = timezone.now()
+        security_event.save()
+
+    @classmethod
+    def _has_subject_identifier(cls, subject):
+        """Return whether the event subject contains an identifier we understand."""
+        return bool(subject.get("sub") or subject.get("email"))
+
+    @classmethod
+    def _event_mutates_user(cls, event_type):
+        """Return whether handling the event is allowed to update the user model."""
+        return event_type in cls.user_mutation_event_types
+
     @classmethod
     def _get_user(cls, subject):
         """Get User model from email or UUID."""
@@ -165,36 +196,36 @@ class SecurityEventHandler:
         """Handle specific event types."""
         try:
             subject = event_data.get("subject", {})
-            user = cls._get_user(subject)
+            try:
+                user = cls._get_user(subject)
+            except ValueError:
+                if cls._event_mutates_user(
+                    event_type
+                ) or not cls._has_subject_identifier(subject):
+                    raise
 
-            # Convert Unix timestamp to datetime if present
-            iat_timestamp = decoded_jwt.get("iat")
-            issued_at = None
-            if iat_timestamp:
-                try:
-                    issued_at = datetime.fromtimestamp(
-                        iat_timestamp, tz=dt_timezone.utc
-                    )
-                except (ValueError, TypeError) as e:
-                    logger.warning(f"Error converting timestamp {iat_timestamp}: {e}")
+                security_event = cls._create_security_event(
+                    None, event_type, event_data, decoded_jwt
+                )
+                cls._mark_processed(security_event)
+                logger.warning(
+                    "Recorded %s event with unmatched subject %s. "
+                    "No user mutation was applied; email is synced from OIDC "
+                    "claims on login.",
+                    event_type,
+                    subject,
+                )
+                return
 
-            security_event = SecurityEventToken.objects.create(
-                user=user,
-                email=user.email,
-                event_type=event_type,
-                event_data=event_data,
-                jwt_id=decoded_jwt.get("jti"),
-                issuer=decoded_jwt.get("iss"),
-                issued_at=issued_at,
+            security_event = cls._create_security_event(
+                user, event_type, event_data, decoded_jwt
             )
 
             # Call the appropriate handler
             handler = cls.handler_map.get(event_type, cls._handle_unknown_event)
             handler(security_event)
 
-            security_event.processed = True
-            security_event.processed_at = timezone.now()
-            security_event.save()
+            cls._mark_processed(security_event)
 
         except Exception as e:
             logger.exception(f"Error handling event {event_type}: {e}")

--- a/tdrs-backend/tdpservice/security/event_handler.py
+++ b/tdrs-backend/tdpservice/security/event_handler.py
@@ -166,7 +166,6 @@ class SecurityEventHandler:
         try:
             subject = event_data.get("subject", {})
             user = cls._get_user(subject)
-            print(f"\n\nEvent Data: {event_data}\n\n")
 
             # Convert Unix timestamp to datetime if present
             iat_timestamp = decoded_jwt.get("iat")

--- a/tdrs-backend/tdpservice/security/event_handler.py
+++ b/tdrs-backend/tdpservice/security/event_handler.py
@@ -166,6 +166,7 @@ class SecurityEventHandler:
         try:
             subject = event_data.get("subject", {})
             user = cls._get_user(subject)
+            print(f"\n\nEvent Data: {event_data}\n\n")
 
             # Convert Unix timestamp to datetime if present
             iat_timestamp = decoded_jwt.get("iat")

--- a/tdrs-backend/tdpservice/security/test/test_event_handler.py
+++ b/tdrs-backend/tdpservice/security/test/test_event_handler.py
@@ -49,17 +49,25 @@ def email_changed_event_data(stt_data_analyst):
     """Mock event data for email changed: includes old and new emails."""
     old_email = stt_data_analyst.email
     new_email = "new_email@example.com"
-    return {"subject": {"email": old_email, "subject_type": new_email}}
+    return {
+        "subject": {"email": old_email, "subject_type": "email"},
+        "new-value": new_email,
+    }
+
+
+@pytest.fixture
+def email_changed_event_data_without_new_value(stt_data_analyst):
+    """Mock Login.gov event data for email changed without a new email."""
+    return {"subject": {"email": stt_data_analyst.email, "subject_type": "email"}}
 
 
 @pytest.fixture
 def email_recycled_event_data(stt_data_analyst):
     """Mock event data for email recycled: includes the recycled email."""
-    # Only the old email is relevant for handler logging; use a placeholder for subject_type
     return {
         "subject": {
             "email": stt_data_analyst.email,
-            "subject_type": "unused@example.com",
+            "subject_type": "email",
         }
     }
 
@@ -262,7 +270,7 @@ class TestSecurityEventHandler:
 
         stt_data_analyst.refresh_from_db()
 
-        new_email = email_changed_event_data["subject"]["subject_type"]
+        new_email = email_changed_event_data["new-value"]
         assert stt_data_analyst.email == new_email
         assert stt_data_analyst.username == new_email
 
@@ -277,6 +285,31 @@ class TestSecurityEventHandler:
         assert token.issued_at == datetime.fromtimestamp(
             decoded_jwt["iat"], tz=timezone.utc
         )
+
+    @pytest.mark.django_db
+    def test_email_changed_without_new_value_does_not_update_user(
+        self, stt_data_analyst, email_changed_event_data_without_new_value, decoded_jwt
+    ):
+        """Test Login.gov identifier-changed payload does not set email to subject_type."""
+        prev_email = stt_data_analyst.email
+        prev_username = stt_data_analyst.username
+
+        event_type = SecurityEventType.EMAIL_CHANGED
+        SecurityEventHandler.handle_event(
+            event_type, email_changed_event_data_without_new_value, decoded_jwt
+        )
+
+        stt_data_analyst.refresh_from_db()
+
+        assert stt_data_analyst.email == prev_email
+        assert stt_data_analyst.username == prev_username
+
+        assert SecurityEventToken.objects.count() == 1
+        token = SecurityEventToken.objects.first()
+        assert token.user == stt_data_analyst
+        assert token.processed is True
+        assert token.event_type == event_type
+        assert token.event_data == email_changed_event_data_without_new_value
 
     @pytest.mark.django_db
     def test_email_recycled(

--- a/tdrs-backend/tdpservice/security/test/test_event_handler.py
+++ b/tdrs-backend/tdpservice/security/test/test_event_handler.py
@@ -231,6 +231,55 @@ class TestSecurityEventHandler:
         )
 
     @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            SecurityEventType.MFA_LOCKED,
+            SecurityEventType.EMAIL_CHANGED,
+            SecurityEventType.EMAIL_RECYCLED,
+            SecurityEventType.PASSWORD_RESET,
+            SecurityEventType.RECOVERY_ACTIVATED,
+            SecurityEventType.RECOVERY_INFORMATION_CHANGED,
+            SecurityEventType.REPROOF_COMPLETE,
+        ],
+    )
+    def test_non_mutating_events_do_not_update_user(
+        self, stt_data_analyst, event_type, decoded_jwt
+    ):
+        """Test only account status and purge events mutate the user model."""
+        prev_email = stt_data_analyst.email
+        prev_username = stt_data_analyst.username
+        prev_active = stt_data_analyst.is_active
+        prev_login_gov_uuid = str(stt_data_analyst.login_gov_uuid)
+        prev_status = stt_data_analyst.account_approval_status
+        event_data = {"subject": {"sub": str(stt_data_analyst.login_gov_uuid)}}
+
+        if event_type in {
+            SecurityEventType.EMAIL_CHANGED,
+            SecurityEventType.EMAIL_RECYCLED,
+        }:
+            event_data = {
+                "subject": {
+                    "email": stt_data_analyst.email,
+                    "subject_type": "email",
+                }
+            }
+
+        SecurityEventHandler.handle_event(event_type, event_data, decoded_jwt)
+
+        stt_data_analyst.refresh_from_db()
+
+        assert stt_data_analyst.email == prev_email
+        assert stt_data_analyst.username == prev_username
+        assert stt_data_analyst.is_active == prev_active
+        assert str(stt_data_analyst.login_gov_uuid) == prev_login_gov_uuid
+        assert stt_data_analyst.account_approval_status == prev_status
+
+        token = SecurityEventToken.objects.first()
+        assert token.processed is True
+        assert token.event_type == event_type
+
+    @pytest.mark.django_db
     def test_mfa_locked(self, stt_data_analyst, event_data, decoded_jwt):
         """Test handling of mfa-locked event."""
         prev_email = stt_data_analyst.email
@@ -262,7 +311,10 @@ class TestSecurityEventHandler:
     def test_email_changed(
         self, stt_data_analyst, email_changed_event_data, decoded_jwt
     ):
-        """Test handling email-changed event updates user's email and username."""
+        """Test handling email-changed event does not update user's email and username."""
+        prev_email = stt_data_analyst.email
+        prev_username = stt_data_analyst.username
+
         event_type = SecurityEventType.EMAIL_CHANGED
         SecurityEventHandler.handle_event(
             event_type, email_changed_event_data, decoded_jwt
@@ -270,9 +322,8 @@ class TestSecurityEventHandler:
 
         stt_data_analyst.refresh_from_db()
 
-        new_email = email_changed_event_data["new-value"]
-        assert stt_data_analyst.email == new_email
-        assert stt_data_analyst.username == new_email
+        assert stt_data_analyst.email == prev_email
+        assert stt_data_analyst.username == prev_username
 
         assert SecurityEventToken.objects.count() == 1
         token = SecurityEventToken.objects.first()
@@ -310,6 +361,59 @@ class TestSecurityEventHandler:
         assert token.processed is True
         assert token.event_type == event_type
         assert token.event_data == email_changed_event_data_without_new_value
+
+    @pytest.mark.django_db
+    def test_email_changed_for_unknown_email_records_processed_event(
+        self, caplog, decoded_jwt
+    ):
+        """Test Login.gov identifier-changed can arrive with a new unknown email."""
+        event_type = SecurityEventType.EMAIL_CHANGED
+        event_data = {
+            "subject": {
+                "email": "new_login_email@example.com",
+                "subject_type": "email",
+            }
+        }
+
+        with caplog.at_level(logging.WARNING):
+            SecurityEventHandler.handle_event(event_type, event_data, decoded_jwt)
+
+        assert "No user found with the provided 'email'" not in caplog.text
+        assert "unmatched subject" in caplog.text
+
+        assert SecurityEventToken.objects.count() == 1
+        token = SecurityEventToken.objects.first()
+        assert token.user is None
+        assert token.email == "new_login_email@example.com"
+        assert token.processed is True
+        assert token.processed_at is not None
+        assert token.event_type == event_type
+        assert token.event_data == event_data
+        assert token.jwt_id == decoded_jwt["jti"]
+        assert token.issuer == decoded_jwt["iss"]
+
+    @pytest.mark.django_db
+    def test_non_mutating_event_for_unknown_sub_records_processed_event(
+        self, caplog, decoded_jwt
+    ):
+        """Test non-mutating events with an unknown sub are recorded for audit."""
+        event_type = SecurityEventType.PASSWORD_RESET
+        event_data = {"subject": {"sub": str(uuid.uuid4())}}
+
+        with caplog.at_level(logging.WARNING):
+            SecurityEventHandler.handle_event(event_type, event_data, decoded_jwt)
+
+        assert "No user found with login_gov_uuid" not in caplog.text
+        assert "unmatched subject" in caplog.text
+
+        assert SecurityEventToken.objects.count() == 1
+        token = SecurityEventToken.objects.first()
+        assert token.user is None
+        assert token.email is None
+        assert token.processed is True
+        assert token.processed_at is not None
+        assert token.event_type == event_type
+        assert token.event_data == event_data
 
     @pytest.mark.django_db
     def test_email_recycled(
@@ -384,9 +488,9 @@ class TestSecurityEventHandler:
 
     @pytest.mark.django_db
     def test_handle_event_user_not_found(self, caplog):
-        """Test handling event when user is not found."""
+        """Test handling user-mutating event when user is not found."""
 
-        event_type = SecurityEventType.UNKNOWN_EVENT
+        event_type = SecurityEventType.ACCOUNT_DISABLED
         login_gov_uuid = uuid.uuid4()
         event_data = {"subject": {"sub": str(login_gov_uuid)}}
         decoded_jwt = {}

--- a/tdrs-backend/tdpservice/users/api/login.py
+++ b/tdrs-backend/tdpservice/users/api/login.py
@@ -228,7 +228,6 @@ class TokenAuthorizationOIDC(ObtainAuthToken):
         user = CustomAuthentication.authenticate(**auth_options)
         logging.debug("user obj:{}".format(user))
         if user:
-            self._sync_user_email(user, email)
             if (
                 not user.is_active
                 or user.account_approval_status
@@ -237,6 +236,7 @@ class TokenAuthorizationOIDC(ObtainAuthToken):
                 raise InactiveUser(
                     f"Login failed, user account is inactive: {user.username}"
                 )
+            self._sync_user_email(user, email)
         else:
             user, login_msg = self._handle_user(email, sub, auth_options)
 

--- a/tdrs-backend/tdpservice/users/api/login.py
+++ b/tdrs-backend/tdpservice/users/api/login.py
@@ -121,6 +121,16 @@ class TokenAuthorizationOIDC(ObtainAuthToken):
         """Handle user email exceptions."""
         pass
 
+    def _sync_user_email(self, user, email):
+        """Sync the stored user email from trusted OIDC claims."""
+        if not email or (user.email == email and user.username == email):
+            return
+
+        user.email = email
+        user.username = email
+        user.save(update_fields=["email", "username"])
+        logger.info("Updated user email from OIDC claims: %s", user.username)
+
     def _handle_user(self, email, sub, auth_options):
         """Handle user."""
         User = get_user_model()
@@ -217,14 +227,17 @@ class TokenAuthorizationOIDC(ObtainAuthToken):
         # corresponding emails externally.
         user = CustomAuthentication.authenticate(**auth_options)
         logging.debug("user obj:{}".format(user))
-        if user and (
-            not user.is_active
-            or user.account_approval_status == AccountApprovalStatusChoices.DEACTIVATED
-        ):
-            raise InactiveUser(
-                f"Login failed, user account is inactive: {user.username}"
-            )
-        elif not user:
+        if user:
+            self._sync_user_email(user, email)
+            if (
+                not user.is_active
+                or user.account_approval_status
+                == AccountApprovalStatusChoices.DEACTIVATED
+            ):
+                raise InactiveUser(
+                    f"Login failed, user account is inactive: {user.username}"
+                )
+        else:
             user, login_msg = self._handle_user(email, sub, auth_options)
 
         self.verify_email(user)

--- a/tdrs-backend/tdpservice/users/oidc.py
+++ b/tdrs-backend/tdpservice/users/oidc.py
@@ -80,6 +80,7 @@ class KeycloakOIDCBackend(OIDCAuthenticationBackend):
         """Update existing user attributes from Keycloak claims on each login."""
         login_gov_uuid = claims.get("login_gov_uuid")
         hhs_id = claims.get("hhs_id")
+        email = claims.get("email", "").lower()
         changed = False
 
         if login_gov_uuid and str(user.login_gov_uuid) != login_gov_uuid:
@@ -88,6 +89,11 @@ class KeycloakOIDCBackend(OIDCAuthenticationBackend):
 
         if hhs_id and user.hhs_id != hhs_id:
             user.hhs_id = hhs_id
+            changed = True
+
+        if email and (user.email != email or user.username != email):
+            user.email = email
+            user.username = email
             changed = True
 
         if changed:

--- a/tdrs-backend/tdpservice/users/test/test_oidc.py
+++ b/tdrs-backend/tdpservice/users/test/test_oidc.py
@@ -131,6 +131,24 @@ class TestUpdateUser:
         updated = backend.update_user(user, claims)
         assert updated.hhs_id == "EXISTING1234"
 
+    def test_update_user_syncs_email_from_claims(self, backend):
+        """Updates the stored email when the IdP reports a new one for the same user."""
+        user = UserFactory(
+            username="old_email@example.com",
+            email="old_email@example.com",
+            hhs_id=None,
+        )
+        claims = {
+            "email": "new_email@example.com",
+            "login_gov_uuid": str(user.login_gov_uuid),
+        }
+
+        updated = backend.update_user(user, claims)
+        updated.refresh_from_db()
+
+        assert updated.username == "new_email@example.com"
+        assert updated.email == "new_email@example.com"
+
 
 @pytest.mark.django_db
 class TestVerifyClaims:

--- a/tdrs-backend/tdpservice/users/test/test_primary_login_gov_security_events.py
+++ b/tdrs-backend/tdpservice/users/test/test_primary_login_gov_security_events.py
@@ -94,7 +94,7 @@ def test_user_changed_login_gov_email(
     user,
     client,
 ):
-    """Test EMAIL_CHANGED SET updates user email and username."""
+    """Test EMAIL_CHANGED SET updates user email and username when new-value is present."""
     old_email = user.email
     new_email = "new_email@example.com"
 
@@ -110,7 +110,8 @@ def test_user_changed_login_gov_email(
     decoded_jwt = {
         "events": {
             SecurityEventType.EMAIL_CHANGED: {
-                "subject": {"email": old_email, "subject_type": new_email}
+                "subject": {"email": old_email, "subject_type": "email"},
+                "new-value": new_email,
             }
         },
         "iss": "https://login.gov",
@@ -137,11 +138,70 @@ def test_user_changed_login_gov_email(
     assert token.user == user
     assert token.event_type == SecurityEventType.EMAIL_CHANGED
     assert token.event_data == {
-        "subject": {"email": old_email, "subject_type": new_email}
+        "subject": {"email": old_email, "subject_type": "email"},
+        "new-value": new_email,
     }
     assert token.jwt_id == "test_jti_email_change_e2e"
     assert token.issuer == "https://login.gov"
     assert token.issued_at == datetime.fromtimestamp(iat, tz=dt_timezone.utc)
+    assert token.processed is True
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("tdpservice.security.views.requests.get")
+@patch("tdpservice.security.views.jwt.get_unverified_header")
+@patch("tdpservice.security.views.jwt.decode")
+@patch("tdpservice.security.views.jwt.algorithms.RSAAlgorithm.from_jwk")
+def test_user_changed_login_gov_email_without_new_value_does_not_update_user(
+    mock_from_jwk,
+    mock_decode,
+    mock_get_unverified_header,
+    mock_requests_get,
+    user,
+    client,
+):
+    """Test Login.gov identifier-changed SET does not set email to subject_type."""
+    old_email = user.email
+    old_username = user.username
+
+    mock_requests_get.side_effect = [
+        MagicMock(json=lambda: {"jwks_uri": "https://login.gov/jwks"}),
+        MagicMock(json=lambda: {"keys": [{"kid": "test_kid"}]}),
+    ]
+    mock_get_unverified_header.return_value = {"kid": "test_kid"}
+    mock_from_jwk.return_value = MagicMock()
+
+    iat = int(timezone.now().timestamp())
+    decoded_jwt = {
+        "events": {
+            SecurityEventType.EMAIL_CHANGED: {
+                "subject": {"email": old_email, "subject_type": "email"}
+            }
+        },
+        "iss": "https://login.gov",
+        "iat": iat,
+        "jti": "test_jti_email_change_no_new_value_e2e",
+    }
+    mock_decode.return_value = decoded_jwt
+
+    url = reverse("event-token")
+    jwt_token = "header.payload.signature"
+    response = client.post(url, data=jwt_token, content_type="application/secevent+jwt")
+
+    assert response.status_code == 200
+
+    user.refresh_from_db()
+    assert user.email == old_email
+    assert user.username == old_username
+
+    assert SecurityEventToken.objects.count() == 1
+    token = SecurityEventToken.objects.first()
+    assert token.user == user
+    assert token.event_type == SecurityEventType.EMAIL_CHANGED
+    assert token.event_data == {
+        "subject": {"email": old_email, "subject_type": "email"}
+    }
+    assert token.jwt_id == "test_jti_email_change_no_new_value_e2e"
     assert token.processed is True
 
 

--- a/tdrs-backend/tdpservice/users/test/test_primary_login_gov_security_events.py
+++ b/tdrs-backend/tdpservice/users/test/test_primary_login_gov_security_events.py
@@ -10,7 +10,10 @@ from django.utils import timezone
 import pytest
 
 from tdpservice.security.models import SecurityEventToken, SecurityEventType
-from tdpservice.users.api.login import TokenAuthorizationOIDC
+from tdpservice.users.api.login import (
+    TokenAuthorizationLoginDotGov,
+    TokenAuthorizationOIDC,
+)
 
 
 @pytest.mark.django_db
@@ -81,6 +84,40 @@ def test_login_gov_uuid_change_without_account_purged(user):
     )
 
 
+@pytest.mark.django_db
+@patch("tdpservice.users.api.login.TokenAuthorizationOIDC.login_user")
+def test_login_gov_user_email_syncs_when_sub_matches(mock_login_user, user, rf):
+    """Test a Login.gov email change is reflected from OIDC claims on next login."""
+    old_email = "old_email@example.com"
+    new_email = "new_email@example.com"
+    user.username = old_email
+    user.email = old_email
+    user.login_gov_uuid = uuid.uuid4()
+    user.save()
+
+    request = rf.get("/oidc/login.gov")
+    request.session = {}
+    view = TokenAuthorizationLoginDotGov()
+
+    result_user = view.handle_user(
+        request,
+        "id-token",
+        {
+            "id_token": {
+                "sub": str(user.login_gov_uuid),
+                "email": new_email,
+            },
+            "access_token": None,
+        },
+    )
+
+    user.refresh_from_db()
+    assert result_user == user
+    assert user.email == new_email
+    assert user.username == new_email
+    mock_login_user.assert_called_once()
+
+
 @pytest.mark.django_db(transaction=True)
 @patch("tdpservice.security.views.requests.get")
 @patch("tdpservice.security.views.jwt.get_unverified_header")
@@ -94,8 +131,9 @@ def test_user_changed_login_gov_email(
     user,
     client,
 ):
-    """Test EMAIL_CHANGED SET updates user email and username when new-value is present."""
+    """Test EMAIL_CHANGED SET records the event without updating user email."""
     old_email = user.email
+    old_username = user.username
     new_email = "new_email@example.com"
 
     # Configure external dependencies and JWT decoding
@@ -127,12 +165,10 @@ def test_user_changed_login_gov_email(
 
     assert response.status_code == 200
 
-    # User should be updated
     user.refresh_from_db()
-    assert user.email == new_email
-    assert user.username == new_email
+    assert user.email == old_email
+    assert user.username == old_username
 
-    # Token should be recorded with correct metadata
     assert SecurityEventToken.objects.count() == 1
     token = SecurityEventToken.objects.first()
     assert token.user == user


### PR DESCRIPTION
## Summary of Changes
- Update identifier changed logic to NOT mutate the User model. The SET does NOT send the UUID of the user for this event and can optionally include the new email that the old email was changed to. Because of this, we can NOT deterministically try to update user data from this event. We track that the event occurred and that is it. When the user re-authenticates for the following session after the event, we are then able to deterministically update the username and email on the User model.

## How to Test
- Deploy to an environment tied to Login.gov `push_url` config. E.g. `raft`, `staging`, `prod`
- Authenticate with login.gov and elect to view your login.gov profile
- Add a new email address to your account and verify it. Ensure this email is NOT already associated with a user in TDP
- Delete your old email account
- Verify you see an Email Changed event in the SET tab in the DAC
- Logout of your current session
- Log back in with the email you just changed to
- Verify your new email is set on your Django user
- You can also verify on the SETs that the user reference is now your new email as opposed to it saying you changed your old email to old email

See screenshot below for my test verification in `raft`. 

<img width="1017" height="244" alt="Screenshot 2026-05-11 at 2 47 23 PM" src="https://github.com/user-attachments/assets/7139ef05-8d00-4a45-88fb-4704e9df1ff3" />


## Deliverables
_More details on how deliverables herein are assessed included [here](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverables)._

### [Deliverable 1: Accepted Features](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-1-Accepted-Features)

Checklist of ACs:
+ [ ] [**_insert ACs here_**]
+ [ ] **`lfrohlich`** and/or **`adpennington`**  confirmed that ACs are met.

### [Deliverable 2: Tested Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-2-Tested-Code)

+ Are all areas of code introduced in this PR meaningfully tested?
  + [ ] If this PR introduces backend code changes, are they meaningfully tested?
  + [ ] If this PR introduces frontend code changes, are they meaningfully tested?
+ Are code coverage minimums met?
  + [ ] Frontend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)
  + [ ] Backend coverage: [_insert coverage %_] (see `CodeCov Report` comment in PR)

### [Deliverable 3: Properly Styled Code](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-3-Properly-Styled-Code)

+ [ ] Are backend code style checks passing on CircleCI?
+ [ ] Are frontend code style checks passing on CircleCI?
+ [ ] Are code maintainability principles being followed?

### [Deliverable 4: Accessible](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-4-Accessibility)

+ [ ] Does this PR complete the epic? 
+ [ ] Are links included to any other gov-approved PRs associated with epic?
+ [ ] Does PR include documentation for Raft's a11y review? 
+ [ ] Did automated and manual testing with `iamjolly` and `ttran-hub` using Accessibility Insights reveal any errors introduced in this PR?


### [Deliverable 5: Deployed](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-5-Deployed)

+ [ ] Was the code successfully deployed via automated CircleCI process to development on Cloud.gov?

### [Deliverable 6: Documented](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-6-Code-documentation)

+ [ ] Does this PR provide background for why coding decisions were made?
+ [ ] If this PR introduces backend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces frontend code, is that code easy to understand and sufficiently documented, both inline and overall?
+ [ ] If this PR introduces dependencies, are their licenses documented?
+ [ ] Can reviewer explain and take ownership of these elements presented in this code review?

### [Deliverable 7: Secure](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-7-Secure)

+ [ ] Does the OWASP Scan pass on CircleCI?
+ [ ] Do manual code review and manual testing detect any new security issues?
+ [ ] If new issues detected, is investigation and/or remediation plan documented? 

### [Deliverable 8: User Research](https://github.com/raft-tech/TANF-app/blob/develop/docs/How-We-Work/our-priorities-values-expectations.md#Deliverable-8-User-Research)

Research product(s) clearly articulate(s):
+ [ ] the purpose of the research
+ [ ] methods used to conduct the research 
+ [ ] who participated in the research
+ [ ] what was tested and how
+ [ ] impact of research on TDP
+ [ ] (_if applicable_) final design mockups produced for TDP development 


